### PR TITLE
update zh_cn.json based on CFPA contributions

### DIFF
--- a/src/main/resources/assets/slashblade/lang/zh_cn.json
+++ b/src/main/resources/assets/slashblade/lang/zh_cn.json
@@ -158,6 +158,7 @@
     "adv.slashblade.guard_just":  "能力      -格挡-",
     "adv.slashblade.guard_just.desc": "将敌人的攻击无效\n高评价状态中不会消耗耐久度\n评价会上升\n键位：\n潜行(⚪)：%s\n指令：\n在受到攻击时 ⚪",
   
+    
     "adv.slashblade.summonedswords": "射技      -幻影剑-",
     "adv.slashblade.summonedswords.desc": "消耗1点经验值，射出幻影剑\n键位：\n%s(♠)：%s\n指令：\n♠",
     "adv.slashblade.spiral_swords":  "射技      -环形幻剑阵-",

--- a/src/main/resources/assets/slashblade/lang/zh_cn.json
+++ b/src/main/resources/assets/slashblade/lang/zh_cn.json
@@ -158,7 +158,7 @@
     "adv.slashblade.guard_just":  "能力      -格挡-",
     "adv.slashblade.guard_just.desc": "将敌人的攻击无效\n高评价状态中不会消耗耐久度\n评价会上升\n键位：\n潜行(⚪)：%s\n指令：\n在受到攻击时 ⚪",
   
-    
+
     "adv.slashblade.summonedswords": "射技      -幻影剑-",
     "adv.slashblade.summonedswords.desc": "消耗1点经验值，射出幻影剑\n键位：\n%s(♠)：%s\n指令：\n♠",
     "adv.slashblade.spiral_swords":  "射技      -环形幻剑阵-",
@@ -171,7 +171,7 @@
     "adv.slashblade.heavy_rain_swords.desc": "消耗5点经验值，将幻影剑连绵不绝地在敌人头上降下\n键位：\n%s(♠)：%s\n后退(ᐁ)：%s\n前进(ᐃ)：%s\n潜行(⚪)：%s\n指令：\n⚪+ᐁ to ᐃ+♠ 按住",
   
   
-  
+
     "adv.slashblade.exeffect": "附魔增效",
     "adv.slashblade.exeffect.desc": "附魔提供额外的效果提升",
   

--- a/src/main/resources/assets/slashblade/lang/zh_cn.json
+++ b/src/main/resources/assets/slashblade/lang/zh_cn.json
@@ -50,7 +50,7 @@
     "item.slashblade.ex.fox.black.desc": "安宁的标志",
     "item.slashblade.ex.fox.black.material": "刀组件「黑狐」",
   
-    "item.slashblade.ex.yuzukitukumo": "宝刀「付丧」结月",
+    "item.slashblade.yuzukitukumo": "宝刀「付丧」结月",
     "item.slashblade.ex.tukumo.desc": "结月刀「付丧」\n铁制刀刃的轨迹",
     "item.slashblade.ex.tukumo.material": "刀组件「付丧」",
   

--- a/src/main/resources/assets/slashblade/lang/zh_cn.json
+++ b/src/main/resources/assets/slashblade/lang/zh_cn.json
@@ -1,0 +1,183 @@
+{
+    "itemGroup.slashblade": "拔刀剑",
+    "itemGroup.slashblade.desc": "堕入阿修罗之道",
+  
+    "attribute.name.generic.reachDistance":"攻击距离",
+  
+    "stat.slashblade.sword_summoned": "召唤幻影剑",
+    "entity.slashblade.abstract_summoned_sword": "幻影剑",
+  
+    "slashblade.tooltip.killcount": "杀敌数：%1$s",
+    "slashblade.tooltip.refine": "精炼次数：%1$s",
+  
+    "slashblade.tooltip.material": "合成条件",
+    "slashblade.tooltip.material.requiredobjects.anvil": "合成场所：铁砧",
+    "slashblade.tooltip.material.killcount": "杀敌数≧%1$s",
+    "slashblade.tooltip.material.refine": "精炼次数≧%1$s",
+    "slashblade.tooltip.material.level": "等级≧%1$s",
+    "slashblade.tooltip.material.broken": "断刀",
+    "slashblade.tooltip.material.noscabbard": "无鞘",
+    "slashblade.tooltip.material.enchantments": "附魔",
+    
+    "item.slashblade.slashblade": "无铭「无名」",
+    "item.slashblade.slashblade.desc": "合成修理的悲剧\n无垢之器",
+    "item.slashblade.slashblade_wood": "无铭刀「木偶」",
+    "item.slashblade.simple.wood.desc": "带鞘的木刀",
+    "item.slashblade.slashblade_white": "利刀「白鞘」",
+    "item.slashblade.simple.white.desc": "铁制的刀刃",
+    "item.slashblade.simple.white.material": "刀组件「白」",
+    "item.slashblade.slashblade_bamboo": "无铭刀「竹光」",
+    "item.slashblade.simple.bamboo.desc": "未完成的工艺品",
+    "item.slashblade.simple.bamboo.material": "刀组件「竹」",
+    "item.slashblade.slashblade_silverbamboo": "名刀「银纸竹光」",
+    "item.slashblade.simple.silverbamboo.desc": "工艺品",
+    "item.slashblade.simple.silverbamboo.material": "刀组件「虚荣」",
+    "item.slashblade.simple.iron": "拔刀剑「」",
+    "item.slashblade.simple.iron.desc": "伊始",
+    "item.slashblade.simple.iron.material": "刀组件「铁」",
+
+    "item.slashblade.yamato": "阎魔刀",
+    "item.slashblade.sange": "散华",
+  
+    "item.slashblade.ex.ruby": "利刀「无名」红玉",
+    "item.slashblade.ex.ruby.desc": "杰作",
+    "item.slashblade.ex.ruby.material": "刀组件「红玉」",
+  
+    "item.slashblade.ex.fox.white": "狐月刀「白狐」",
+    "item.slashblade.ex.fox.white.desc": "幸运的标志",
+    "item.slashblade.ex.fox.white.material": "刀组件「白狐」",
+    "item.slashblade.ex.fox.black": "狐月刀「黑狐」",
+    "item.slashblade.ex.fox.black.desc": "安宁的标志",
+    "item.slashblade.ex.fox.black.material": "刀组件「黑狐」",
+  
+    "item.slashblade.ex.yuzukitukumo": "宝刀「付丧」结月",
+    "item.slashblade.ex.tukumo.desc": "结月刀「付丧」\n铁制刀刃的轨迹",
+    "item.slashblade.ex.tukumo.material": "刀组件「付丧」",
+  
+    "item.slashblade.muramasa": "「千鹤」村正",
+    "item.slashblade.ex.muramasa.desc": "失传的名刀村正",
+    "item.slashblade.ex.muramasa.material": "刀组件「村正」",
+  
+    
+    "item.slashblade.proudsoul": "耀魂碎片",
+    "item.slashblade.proudsoul_tiny": "破碎的耀魂",
+    "item.slashblade.proudsoul_ingot": "耀魂铁锭",
+    "item.slashblade.proudsoul_sphere": "耀魂宝珠",
+    "item.slashblade.proudsoul_crystal": "耀魂结晶",
+    "item.slashblade.proudsoul_trapezohedron": "耀偏方三八面魂",
+    "item.slashblade.proudsoul_activated":"饥渴的耀偏方三八面魂",
+    "item.slashblade.proudsoul_awakened":"玄奥的耀偏方三八面魂",
+    "item.slashblade.proudsoul_tiny.dark":"破碎的耀魂之茧",
+  
+    "entity.slashblade.blade_stand_entity": "刀挂台",
+    "item.slashblade.bladestand_1": "立式单刀挂台",
+    "item.slashblade.bladestand_2": "立式双刀挂台",
+    "item.slashblade.bladestand_v": "立式竖刀挂台",
+    "item.slashblade.bladestand_s": "立式短刀挂台",
+    "item.slashblade.bladestand_1w": "挂式单刀挂台",
+    "item.slashblade.bladestand_2w": "挂式双刀挂台",
+  
+    "adv.slashblade.proudsoul": "强化限制=50\n利刃易折\n断刃之中高傲的灵魂之火",
+    "adv.slashblade.proudsoul_tiny": "强化限制=10\n幽微闪烁的灵魂之炎",
+    "adv.slashblade.proudsoul_ingot": "强化限制=100\n以高傲紫色之炎锻造的灵铁",
+    "adv.slashblade.proudsoul_sphere": "强化限制=150\n熔炉冶炼\n缭绕着虚幻灵魂之炎的宝珠",
+    "adv.slashblade.proudsoul_crystal": "强化限制=200\n高炉精炼\n灵魂钢铁的核心",
+    "adv.slashblade.proudsoul_trapezohedron": "无限制强化\n烟熏炉熏烤\n摇曳的高傲之结晶\n此乃千锤百炼之终末",
+    "adv.slashblade.proudsoul_activated":"唤醒它的代价是无尽的饥饿\n潜行并单击右键以激活耀偏方三八面魂\n放在快捷栏时会被饥饿所侵袭\n饥饿状态下将继续以饥饿修复刀剑",
+    "adv.slashblade.proudsoul_awakened":"抱元守一，神闲气定\n如此便可反复以饥饿为代价获得破碎的耀魂",
+  
+    "adv.slashblade.reforge":"刀剑重铸",
+    "adv.slashblade.reforge.desc": "用铁砧组装拔刀剑和刀组件",
+  
+    "adv.slashblade.refine": "精炼",
+    "adv.slashblade.refine.desc": "千锤百炼之后，刀剑的潜能亦被释放",
+  
+    "adv.slashblade.white_broken": "折断的利刃",
+    "adv.slashblade.white_broken.desc": "重铸！",
+  
+    "adv.slashblade.bladestand": "刀挂台",
+    "adv.slashblade.bladestand.desc":"刀剑暂歇之处",
+  
+    "adv.slashblade.imitation_broken": "贪慕虚荣",
+    "adv.slashblade.imitation_broken.desc": "一意孤行的下场",
+  
+    "adv.slashblade.movesets": "操作说明",
+    "adv.slashblade.movesets.desc": "指令表",
+  
+    "adv.slashblade.combo_a": "剑技      -连击 A-",
+    "adv.slashblade.combo_a.desc": "键位：\n攻击(♠)：%s\n指令：\n地面\n♠-♠-♠-♠",
+    "adv.slashblade.combo_b": "剑技      -连击 B-",
+    "adv.slashblade.combo_b.desc": "键位：\n攻击(♠)：%s\n指令：\n地面\n♠-♠-♠，停顿后重复 ♠ ",
+    "adv.slashblade.combo_b_max": "完成连击 B",
+    "adv.slashblade.combo_b_max.desc": "撕碎！",
+    "adv.slashblade.combo_c": "剑技      -连击 C-",
+    "adv.slashblade.combo_c.desc": "键位：\n攻击(♠)：%s\n指令：\n地面\n♠-♠，停顿后 ♠",
+    "adv.slashblade.combo_a_ex": "剑技      -连击 A 绝-",
+    "adv.slashblade.combo_a_ex.desc": "键位：\n攻击 ♠：%s\n指令：\n地面\n在力量或饥饿效果时\n♠-♠-♠-♠-♠",
+  
+    "adv.slashblade.aerial_a": "剑技      -御空刀舞 A-",
+    "adv.slashblade.aerial_a.desc": "键位：\n攻击(♠)：%s\n指令：\n滞空\n♠-♠-♠",
+    "adv.slashblade.aerial_b": "剑技      -御空刀舞 B-",
+    "adv.slashblade.aerial_b.desc": "键位：\n攻击(♠)：%s\n指令：\n滞空\n♠-♠，停顿后 ♠-♠",
+    "adv.slashblade.aerial_cleave": "剑技      -空坠斩-",
+    "adv.slashblade.aerial_cleave.desc": "键位：\n攻击(♠)：%s\n后退(ᐁ)：%s\n潜行(⚪)：%s\n指令：\n滞空\n⚪+ᐁ+♠",
+  
+    "adv.slashblade.judgement_cut": "剑技      -次元斩-",
+    "adv.slashblade.judgement_cut.desc": "键位：\n攻击(♠)：%s\n指令：\n♠ 按住，蓄力完毕放开",
+    "adv.slashblade.judgement_cut_just": "剑技      -次元斩-绝-",
+    "adv.slashblade.judgement_cut_just.desc": "键位：\n攻击(♠)：%s\n指令：\n♠ 按住，蓄力完毕时放开",
+    "adv.slashblade.quick_charge": "剑技      -迅速蓄力-",
+    "adv.slashblade.quick_charge.desc": "键位：\n攻击(♠)：%s\n指令：\n在纳刀的瞬间按下 ♠",
+  
+    "adv.slashblade.rapid_slash": "剑技      -迅冲斩-",
+    "adv.slashblade.rapid_slash.desc": "键位：\n攻击(♠)：%s\n前进(ᐃ)：%s\n潜行(⚪)：%s\n指令：\n地面\n⚪+ᐃ+♠",
+    "adv.slashblade.rising_star": "剑技      -星旋天翔-",
+    "adv.slashblade.rising_star.desc": "键位：\n攻击(♠)：%s\n指令：\n迅冲斩后\n♠ 按住，直到命中敌人",
+  
+    "adv.slashblade.upperslash": "剑技      -上斩-",
+    "adv.slashblade.upperslash.desc": "键位：\n攻击(♠)：%s\n后退(ᐁ)：%s\n潜行(⚪)：%s\n指令：\n地面\n⚪+ᐁ+♠",
+    "adv.slashblade.upperslash_jump": "剑技      -跃升斩-",
+    "adv.slashblade.upperslash_jump.desc": "键位：\n攻击(♠)：%s\n指令：\n上斩后\n♠ 按住",
+  
+  
+    "adv.slashblade.air_trick":   "能力      -隔空瞬步-",
+    "adv.slashblade.air_trick.desc": "向注视中的敌人的头上瞬间移动\n键位：\n疾跑(♠)：%s\n前进(ᐃ)：%s\n潜行(⚪)：%s\n指令：\n⚪+ᐃ+♠",
+    "adv.slashblade.trick_down":  "能力      -瞬步退行-",
+    "adv.slashblade.trick_down.desc": "滞空时迅速落地\n键位：\n疾跑(♠)：%s\n后退(ᐁ)：%s\n潜行(⚪)：%s\n指令：\n⚪+ᐁ+♠",
+    "adv.slashblade.trick_dodge": "能力      -瞬步回避-",
+    "adv.slashblade.trick_dodge.desc": "往任意方向瞬间移动躲避伤害\n键位：\n疾跑(♠)：%s\n指令：\n在移动中 ♠",
+    "adv.slashblade.trick_up":    "能力      -瞬步上行-",
+    "adv.slashblade.trick_up.desc": "向上瞬间移动\n键位：\n疾跑(♠)：%s\n前进(ᐃ)：%s\n潜行(⚪)：%s\n指令：\n⚪+ᐃ+♠",
+    "adv.slashblade.enemy_step":  "能力      -借力跳-",
+    "adv.slashblade.enemy_step.desc": "滞空时把敌人作为垫脚石以二段跳\n键位：\n跳跃(□)：%s\n指令：\n滞空靠近敌人时 □",
+    "adv.slashblade.kick_jump":   "能力      -踢跃-",
+    "adv.slashblade.kick_jump.desc": "蹬开墙壁再度跳跃\n键位：\n跳跃(□)：%s\n指令：\n滞空靠近墙壁时 □",
+  
+    "adv.slashblade.guard":       "能力      -防御-",
+    "adv.slashblade.guard.desc": "消耗耐久度将敌人的远程攻击无效\n“行走”中无法发动\n键位：\n潜行(⚪)：%s\n指令：\n⚪",
+    "adv.slashblade.guard_just":  "能力      -格挡-",
+    "adv.slashblade.guard_just.desc": "将敌人的攻击无效\n高评价状态中不会消耗耐久度\n评价会上升\n键位：\n潜行(⚪)：%s\n指令：\n在受到攻击时 ⚪",
+  
+    "adv.slashblade.summonedswords": "射技      -幻影剑-",
+    "adv.slashblade.summonedswords.desc": "消耗1点经验值，射出幻影剑\n键位：\n%s(♠)：%s\n指令：\n♠",
+    "adv.slashblade.spiral_swords":  "射技      -环形幻剑阵-",
+    "adv.slashblade.spiral_swords.desc": "消耗5点经验值，在自身周围形成幻影剑圆阵\n键位：\n%s(♠)：%s\n指令：\n♠ 按住",
+    "adv.slashblade.storm_swords":   "射技      -怒风幻剑阵-",
+    "adv.slashblade.storm_swords.desc": "消耗5点经验值，将幻影剑如同怒风般包围攻击并击飞敌人\n键位：\n%s(♠)：%s\n后退(ᐁ)：%s\n潜行(⚪)：%s\n指令：\n⚪+ᐁ+♠ 按住",
+    "adv.slashblade.blistering_swords": "射技      -急袭幻剑阵-",
+    "adv.slashblade.blistering_swords.desc": "消耗5点经验值，将幻影剑展开快速攻击敌人\n键位：\n%s(♠)：%s\n前进(ᐃ)：%s\n潜行(⚪)：%s\n指令：\n⚪+ᐃ+♠ 按住 放开",
+    "adv.slashblade.heavy_rain_swords": "射技      -暴雨幻剑阵-",
+    "adv.slashblade.heavy_rain_swords.desc": "消耗5点经验值，将幻影剑连绵不绝地在敌人头上降下\n键位：\n%s(♠)：%s\n后退(ᐁ)：%s\n前进(ᐃ)：%s\n潜行(⚪)：%s\n指令：\n⚪+ᐁ to ᐃ+♠ 按住",
+  
+  
+  
+    "adv.slashblade.exeffect": "附魔增效",
+    "adv.slashblade.exeffect.desc": "附魔提供额外的效果提升",
+  
+    "adv.slashblade.exeffect.soul_speed": "灵魂疾行",
+    "adv.slashblade.exeffect.soul_speed.desc": "灵魂疾行每1级能够延长格挡指令输入窗口1tick",
+  
+    "adv.slashblade.exeffect.feather_falling": "缓降",
+    "adv.slashblade.exeffect.feather_falling.desc": "缓降效果的等级将减缓滞空时的下落速度"
+  }
+  


### PR DESCRIPTION
基于 [CFPA#4036](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/pull/4036)。

几个问题：
- [ ] 1. 银纸竹光的描述为何删除？
- [ ] 2. `刀剣の材料箱`在此版本内译为`刀组件`，不同于原有的`刀拵`。是否需要修改？
- [ ] 3. 部分的刀出现了名称改key但是描述不改的情况，是否需要统一？

