### PR TITLE
修复#18拔刀剑渲染黑色问题

### DIFF
--- a/src/main/java/mods/flammpfeil/slashblade/client/renderer/util/BladeRenderState.java
+++ b/src/main/java/mods/flammpfeil/slashblade/client/renderer/util/BladeRenderState.java
@@ -57,8 +57,8 @@ public class BladeRenderState extends RenderStateShard {
                 Util.memoize(RenderType::entitySmoothCutout), true);
         Face.forceQuad = false;
 
-        // renderOverrided(stack, model, target, texture, matrixStackIn, bufferIn,
-        // packedLightIn, Util.memoize(BladeRenderState::getSlashBladeBlend), true);
+        renderOverrided(stack, model, target, texture, matrixStackIn, bufferIn,
+                packedLightIn, Util.memoize(BladeRenderState::getSlashBladeBlend), true);
     }
 
     static public void renderOverridedColorWrite(ItemStack stack, WavefrontObject model, String target,


### PR DESCRIPTION
参见#18，拔刀剑渲染黑色问题
未测试是否有副作用
另附：临时补丁版本：https://github.com/HappyRespawnanchor/Resharped-RenderFix-Patch