### PR TITLE
修正伤害计算公式（去除了不稳定的攻击冷却影响），修复BUG，添加配置

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,11 @@ repositories {
 	maven {
 		name = "TerraformersMC"
 		url = "https://maven.terraformersmc.com/"
-	}    
+	}
+
+    maven {
+        url "https://cursemaven.com"
+    }
 
 }
 
@@ -193,7 +197,10 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
     implementation fg.deobf("dev.kosmx.player-anim:player-animation-lib-forge:${project.player_anim}")
-    
+
+    //假人(含前置)
+    runtimeOnly fg.deobf("curse.maven:selene-499980:6023899")
+    runtimeOnly fg.deobf("curse.maven:mmmmmmmmmmmm-225738:5737040")
         // compile against the JEI API but do not include it at runtime
     compileOnly(fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"))
     compileOnly(fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}"))

--- a/src/main/java/mods/flammpfeil/slashblade/SlashBlade.java
+++ b/src/main/java/mods/flammpfeil/slashblade/SlashBlade.java
@@ -62,6 +62,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
+import static mods.flammpfeil.slashblade.SlashBladeConfig.TRAPEZOHEDRON_MAX_REFINE;
+
 @Mod(SlashBlade.MODID)
 public class SlashBlade {
     public static final String MODID = "slashblade";
@@ -328,7 +330,7 @@ public class SlashBlade {
 
                             @Override
                             public int getEnchantmentValue(ItemStack stack) {
-                                return Integer.MAX_VALUE;
+                                return TRAPEZOHEDRON_MAX_REFINE.get();
                             }
                         });
 

--- a/src/main/java/mods/flammpfeil/slashblade/SlashBladeConfig.java
+++ b/src/main/java/mods/flammpfeil/slashblade/SlashBladeConfig.java
@@ -17,6 +17,7 @@ public class SlashBladeConfig {
 
     public static ForgeConfigSpec.DoubleValue SLASHBLADE_DAMAGE_MULTIPLIER;
     public static ForgeConfigSpec.DoubleValue REFINE_DAMAGE_MULTIPLIER;
+    public static ForgeConfigSpec.IntValue TRAPEZOHEDRON_MAX_REFINE;
 
     
     static {
@@ -56,6 +57,9 @@ public class SlashBladeConfig {
 
         REFINE_DAMAGE_MULTIPLIER = COMMON_BUILDER.comment("S-Rank Bonus: Each Refine × Multiplier'value Damage.[Default: 0.785D]")
                 .defineInRange("refine_damage_multiplier", 0.785D, 0.0D, 1024.0D);
+
+        TRAPEZOHEDRON_MAX_REFINE = COMMON_BUILDER.comment("The maximum number of refine of Trapezohedron.[Default: 2147483647(infinity)]")
+                .defineInRange("max_proud_soul_got", Integer.MAX_VALUE, 200, Integer.MAX_VALUE);
 
         COMMON_BUILDER.pop();
         COMMON_CONFIG = COMMON_BUILDER.build();

--- a/src/main/java/mods/flammpfeil/slashblade/SlashBladeConfig.java
+++ b/src/main/java/mods/flammpfeil/slashblade/SlashBladeConfig.java
@@ -14,6 +14,10 @@ public class SlashBladeConfig {
     public static ForgeConfigSpec.DoubleValue SABIGATANA_SPAWN_CHANCE;
     public static ForgeConfigSpec.DoubleValue BROKEN_SABIGATANA_SPAWN_CHANCE;
     public static ForgeConfigSpec.IntValue REFINE_LEVEL_COST;
+
+    public static ForgeConfigSpec.DoubleValue SLASHBLADE_DAMAGE_MULTIPLIER;
+    public static ForgeConfigSpec.DoubleValue REFINE_DAMAGE_MULTIPLIER;
+
     
     static {
         ForgeConfigSpec.Builder COMMON_BUILDER = new ForgeConfigSpec.Builder();
@@ -46,6 +50,12 @@ public class SlashBladeConfig {
         BEWITCHED_HUNGER_EXHAUSTION = COMMON_BUILDER
                 .comment("Determining the base exhaustion for slashblade's self-repair.")
                 .defineInRange("bewitched_hunger_exhaustion", 0.05D, 0.0001D, Double.MAX_VALUE);
+
+        SLASHBLADE_DAMAGE_MULTIPLIER = COMMON_BUILDER.comment("Blade Damage: Base Damage × Multiplier.[Default: 1.0D]")
+                .defineInRange("slashblade_damage_multiplier", 1.0D, 0.0D, 1024.0D);
+
+        REFINE_DAMAGE_MULTIPLIER = COMMON_BUILDER.comment("S-Rank Bonus: Each Refine × Multiplier'value Damage.[Default: 0.785D]")
+                .defineInRange("refine_damage_multiplier", 0.785D, 0.0D, 1024.0D);
 
         COMMON_BUILDER.pop();
         COMMON_CONFIG = COMMON_BUILDER.build();

--- a/src/main/java/mods/flammpfeil/slashblade/entity/EntityAbstractSummonedSword.java
+++ b/src/main/java/mods/flammpfeil/slashblade/entity/EntityAbstractSummonedSword.java
@@ -53,6 +53,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
+import static mods.flammpfeil.slashblade.SlashBladeConfig.SLASHBLADE_DAMAGE_MULTIPLIER;
+
 public class EntityAbstractSummonedSword extends Projectile implements IShootable {
     private static final EntityDataAccessor<Integer> COLOR = SynchedEntityData
             .<Integer>defineId(EntityAbstractSummonedSword.class, EntityDataSerializers.INT);
@@ -518,7 +520,9 @@ public class EntityAbstractSummonedSword extends Projectile implements IShootabl
         // todo: attack manager
         targetEntity.invulnerableTime = 0;
         float scale = 1f;
-        if (shooter instanceof LivingEntity living) scale = AttackManager.getSlashBladeDamageScale(living);
+        if (shooter instanceof LivingEntity living) {
+            scale = (float) (AttackManager.getSlashBladeDamageScale(living) * SLASHBLADE_DAMAGE_MULTIPLIER.get());
+        }
         float damageValue = i * scale;
         if (targetEntity.hurt(damagesource, damageValue)) {
             Entity hits = targetEntity;

--- a/src/main/java/mods/flammpfeil/slashblade/entity/EntityDrive.java
+++ b/src/main/java/mods/flammpfeil/slashblade/entity/EntityDrive.java
@@ -42,6 +42,8 @@ import net.minecraftforge.network.PlayMessages;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static mods.flammpfeil.slashblade.SlashBladeConfig.SLASHBLADE_DAMAGE_MULTIPLIER;
+
 public class EntityDrive extends EntityAbstractSummonedSword {
     private static final EntityDataAccessor<Integer> COLOR = SynchedEntityData.<Integer>defineId(EntityDrive.class,
             EntityDataSerializers.INT);
@@ -322,7 +324,7 @@ public class EntityDrive extends EntityAbstractSummonedSword {
         targetEntity.invulnerableTime = 0;
         float damageValue = i;
         if(this.getOwner() instanceof LivingEntity living) {
-        	damageValue *= living.getAttributeValue(Attributes.ATTACK_DAMAGE) * AttackManager.getSlashBladeDamageScale(living);
+        	damageValue *= living.getAttributeValue(Attributes.ATTACK_DAMAGE) * AttackManager.getSlashBladeDamageScale(living) * SLASHBLADE_DAMAGE_MULTIPLIER.get();
         }
 
 		if (targetEntity.hurt(damagesource, damageValue)) {

--- a/src/main/java/mods/flammpfeil/slashblade/item/ItemSlashBlade.java
+++ b/src/main/java/mods/flammpfeil/slashblade/item/ItemSlashBlade.java
@@ -435,8 +435,8 @@ public class ItemSlashBlade extends SwordItem {
 				ComboState cs = ComboStateRegistry.REGISTRY.get().getValue(loc) != null
 						? ComboStateRegistry.REGISTRY.get().getValue(loc)
 						: ComboStateRegistry.NONE.get();
-				cs.tickAction(living);
 				if(isSelected)
+					cs.tickAction(living);
 					state.sendChanges(living);
 			}
 		});

--- a/src/main/java/mods/flammpfeil/slashblade/item/ItemSlashBlade.java
+++ b/src/main/java/mods/flammpfeil/slashblade/item/ItemSlashBlade.java
@@ -109,20 +109,25 @@ public class ItemSlashBlade extends SwordItem {
 		if (slot == EquipmentSlot.MAINHAND) {
 			LazyOptional<ISlashBladeState> state = stack.getCapability(BLADESTATE);
 			state.ifPresent(s -> {
+				//刀的状态
 				var swordType = SwordType.from(stack);
+				//获得基础攻击力
 				float baseAttackModifier = s.getBaseAttackModifier();
-
+				//锻造数
 				int refine = s.getRefine();
-				float attackAmplifier = s.getAttackAmplifier() - 1F;
-				if (s.isBroken())
+
+				float attackAmplifier = s.getAttackAmplifier();
+				if (s.isBroken()){
+					//断刀0.5伤害
 					attackAmplifier = -0.5F - baseAttackModifier;
-				else
-					attackAmplifier = (swordType.contains(SwordType.FIERCEREDGE)
-							? 1.0F - (1.0F / (1.0F + (0.1F * refine)))
-							: 1.0F - (1.0F / (1.0F + (0.05F * refine)))) * baseAttackModifier;
+				}else{
+					float refineFactor = swordType.contains(SwordType.FIERCEREDGE) ? 0.1F : 0.05F;
+					//锻造伤害面板增加计算，非线性，收益递减。(理论最大值为额外100%基础攻击)
+					attackAmplifier = (1.0F - (1.0F / (1.0F + (refineFactor * refine)))) * baseAttackModifier;
+				}
 
 				AttributeModifier attack = new AttributeModifier(BASE_ATTACK_DAMAGE_UUID, "Weapon modifier",
-						(double) baseAttackModifier + attackAmplifier, AttributeModifier.Operation.ADDITION);
+						(double) baseAttackModifier + attackAmplifier - 1F, AttributeModifier.Operation.ADDITION);
 
 				result.remove(Attributes.ATTACK_DAMAGE, attack);
 				result.put(Attributes.ATTACK_DAMAGE, attack);

--- a/src/main/java/mods/flammpfeil/slashblade/util/AttackManager.java
+++ b/src/main/java/mods/flammpfeil/slashblade/util/AttackManager.java
@@ -317,7 +317,7 @@ public class AttackManager {
                     AttributeModifier am = new AttributeModifier("RankDamageBonus", modifiedRatio,
                             AttributeModifier.Operation.ADDITION);
 
-                    AttributeModifier scale = new AttributeModifier("SlashBladeDamageScale", 0.25 * getSlashBladeDamageScale(attacker) * SLASHBLADE_DAMAGE_MULTIPLIER.get() - 1.0,
+                    AttributeModifier scale = new AttributeModifier("SlashBladeDamageScale", getSlashBladeDamageScale(attacker) * SLASHBLADE_DAMAGE_MULTIPLIER.get() - 1.0,
                             AttributeModifier.Operation.MULTIPLY_TOTAL);
 
                     try {

--- a/src/main/java/mods/flammpfeil/slashblade/util/PlayerAttackHelper.java
+++ b/src/main/java/mods/flammpfeil/slashblade/util/PlayerAttackHelper.java
@@ -28,7 +28,7 @@ public class PlayerAttackHelper {
                 // 获取攻击者的攻击伤害属性
                 float baseDamage = (float)attacker.getAttributeValue(Attributes.ATTACK_DAMAGE);
                 // 获取附魔伤害加成（针对生物类型），
-                float enchantmentDamageBonus ;// ps:n为等级，锋利加成为(0.5n+0.5)，其余为对对应的生物加成2.5n。
+                float enchantmentDamageBonus ;// ps:杀死类附魔攻击对应的生物加成2.5n。(n为附魔等级)
                 if (target instanceof LivingEntity) {
                     enchantmentDamageBonus  = EnchantmentHelper.getDamageBonus(attacker.getMainHandItem(), ((LivingEntity)target).getMobType());
                 } else {

--- a/src/main/java/mods/flammpfeil/slashblade/util/PlayerAttackHelper.java
+++ b/src/main/java/mods/flammpfeil/slashblade/util/PlayerAttackHelper.java
@@ -35,6 +35,8 @@ public class PlayerAttackHelper {
                     enchantmentDamageBonus  = EnchantmentHelper.getDamageBonus(attacker.getMainHandItem(), MobType.UNDEFINED);
                 }
 
+                // 补正伤害DPS至修改公式前水平
+                baseDamage *= 0.25f;
                 //伤害或附魔伤害>0时
                 if (baseDamage > 0.0F || enchantmentDamageBonus  > 0.0F) {
 

--- a/src/main/java/mods/flammpfeil/slashblade/util/PlayerAttackHelper.java
+++ b/src/main/java/mods/flammpfeil/slashblade/util/PlayerAttackHelper.java
@@ -1,0 +1,156 @@
+package mods.flammpfeil.slashblade.util;
+
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.stats.Stats;
+import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.MobType;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.phys.Vec3;
+
+public class PlayerAttackHelper {
+    public static void attack(Player attacker, Entity target){
+        // 触发Forge事件，以兼容其他模组
+        if (!net.minecraftforge.common.ForgeHooks.onPlayerAttackTarget(attacker, target)) return;
+        // 判断攻击目标是否可以被攻击
+        if (target.isAttackable()) {
+            if (!target.skipAttackInteraction(attacker)) {
+                // 获取攻击者的攻击伤害属性
+                float baseDamage = (float)attacker.getAttributeValue(Attributes.ATTACK_DAMAGE);
+                // 获取附魔伤害加成（针对生物类型），
+                float enchantmentDamageBonus ;// ps:n为等级，锋利加成为(0.5n+0.5)，其余为对对应的生物加成2.5n。
+                if (target instanceof LivingEntity) {
+                    enchantmentDamageBonus  = EnchantmentHelper.getDamageBonus(attacker.getMainHandItem(), ((LivingEntity)target).getMobType());
+                } else {
+                    enchantmentDamageBonus  = EnchantmentHelper.getDamageBonus(attacker.getMainHandItem(), MobType.UNDEFINED);
+                }
+
+                //伤害或附魔伤害>0时
+                if (baseDamage > 0.0F || enchantmentDamageBonus  > 0.0F) {
+
+                    // 获取攻击者的击退属性
+                    float knockback = (float)attacker.getAttributeValue(Attributes.ATTACK_KNOCKBACK); // Forge: Initialize attacker value to the attack knockback attribute of the player, which is by default 0
+                    // 加上当前击退附魔加成
+                    knockback  += EnchantmentHelper.getKnockbackBonus(attacker);
+                    if (attacker.isSprinting()) {
+                        attacker.level().playSound((Player)null, attacker.getX(), attacker.getY(), attacker.getZ(), SoundEvents.PLAYER_ATTACK_KNOCKBACK, attacker.getSoundSource(), 1.0F, 1.0F);
+                        ++knockback ;
+                    }
+
+                    // 暴击
+                    boolean isCritical = attacker.fallDistance > 0.0F && !attacker.onGround() &&
+                            !attacker.onClimbable() && !attacker.isInWater() &&
+                            !attacker.hasEffect(MobEffects.BLINDNESS) &&
+                            !attacker.isPassenger() && target instanceof LivingEntity && !attacker.isSprinting();
+                    net.minecraftforge.event.entity.player.CriticalHitEvent hitResult = net.minecraftforge.common.ForgeHooks.getCriticalHit(attacker, target, isCritical, isCritical ? 1.5F : 1.0F);
+                    isCritical = hitResult != null;
+                    if (isCritical) {
+                        baseDamage *= hitResult.getDamageModifier();
+                    }
+
+                    // 加上附魔伤害加成
+                    baseDamage += enchantmentDamageBonus ;
+
+                    //火焰附加
+                    float preAttackHealth = 0.0F;
+                    boolean shouldSetFire = false;
+                    int fireAspectLevel = EnchantmentHelper.getFireAspect(attacker);
+                    if (target instanceof LivingEntity) {
+                        preAttackHealth  = ((LivingEntity)target).getHealth();
+                        if (fireAspectLevel > 0 && !target.isOnFire()) {
+                            shouldSetFire  = true;
+                            target.setSecondsOnFire(1);
+                        }
+                    }
+
+                    Vec3 vec3 = target.getDeltaMovement();
+                    boolean damageSuccess = target.hurt(attacker.damageSources().playerAttack(attacker), baseDamage);
+                    if (damageSuccess) {
+                        //击退
+                        if (knockback  > 0) {
+                            if (target instanceof LivingEntity) {
+                                ((LivingEntity)target).knockback((double)((float)knockback  * 0.5F), (double) Mth.sin(attacker.getYRot() * ((float)Math.PI / 180F)), (double)(-Mth.cos(attacker.getYRot() * ((float)Math.PI / 180F))));
+                            } else {
+                                target.push((double)(-Mth.sin(attacker.getYRot() * ((float)Math.PI / 180F)) * (float)knockback  * 0.5F), 0.1D, (double)(Mth.cos(attacker.getYRot() * ((float)Math.PI / 180F)) * (float)knockback  * 0.5F));
+                            }
+
+                            attacker.setDeltaMovement(attacker.getDeltaMovement().multiply(0.6D, 1.0D, 0.6D));
+                            attacker.setSprinting(false);
+                        }
+
+                        if (target instanceof ServerPlayer && target.hurtMarked) {
+                            ((ServerPlayer)target).connection.send(new ClientboundSetEntityMotionPacket(target));
+                            target.hurtMarked = false;
+                            target.setDeltaMovement(vec3);
+                        }
+
+                        //音效
+                        if (isCritical) {
+                            attacker.level().playSound((Player)null, attacker.getX(), attacker.getY(), attacker.getZ(), SoundEvents.PLAYER_ATTACK_CRIT, attacker.getSoundSource(), 1.0F, 1.0F);
+                            attacker.crit(target);
+                        }else {
+                            attacker.level().playSound((Player)null, attacker.getX(), attacker.getY(), attacker.getZ(), SoundEvents.PLAYER_ATTACK_WEAK, attacker.getSoundSource(), 1.0F, 1.0F);
+                        }
+
+                        //触发攻击目标的附魔效果
+                        attacker.setLastHurtMob(target);
+                        if (target instanceof LivingEntity) {
+                            EnchantmentHelper.doPostHurtEffects((LivingEntity)target, attacker);
+                        }
+
+                        EnchantmentHelper.doPostDamageEffects(attacker, target);
+                        ItemStack itemstack1 = attacker.getMainHandItem();
+                        Entity entity = target;
+                        if (target instanceof net.minecraftforge.entity.PartEntity) {
+                            entity = ((net.minecraftforge.entity.PartEntity<?>) target).getParent();
+                        }
+
+                        // 减少耐久
+                        if (!attacker.level().isClientSide && !itemstack1.isEmpty() && entity instanceof LivingEntity) {
+                            ItemStack copy = itemstack1.copy();
+                            itemstack1.hurtEnemy((LivingEntity)entity, attacker);
+                            if (itemstack1.isEmpty()) {
+                                net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(attacker, copy, InteractionHand.MAIN_HAND);
+                                attacker.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
+                            }
+                        }
+
+                        if (target instanceof LivingEntity) {
+                            float damageDealt = preAttackHealth  - ((LivingEntity)target).getHealth();
+                            //伤害统计
+                            attacker.awardStat(Stats.DAMAGE_DEALT, Math.round(damageDealt * 10.0F));
+                            //应用完整的火焰附加效果(每级4秒)
+                            if (fireAspectLevel > 0) {
+                                target.setSecondsOnFire(fireAspectLevel * 4);
+                            }
+
+
+                            if (attacker.level() instanceof ServerLevel && damageDealt > 2.0F) {
+                                int k = (int)((double)damageDealt  * 0.5D);
+                                ((ServerLevel)attacker.level()).sendParticles(ParticleTypes.DAMAGE_INDICATOR, target.getX(), target.getY(0.5D), target.getZ(), k, 0.1D, 0.0D, 0.1D, 0.2D);
+                            }
+                        }
+
+                        attacker.causeFoodExhaustion(0.1F);// 消耗饱食度
+                    } else {//伤害未成功应用
+                        attacker.level().playSound((Player)null, attacker.getX(), attacker.getY(), attacker.getZ(), SoundEvents.PLAYER_ATTACK_NODAMAGE, attacker.getSoundSource(), 1.0F, 1.0F);
+                        if (shouldSetFire ) {
+                            //取消预火焰附加效果
+                            target.clearFire();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
1.为开发环境引入假人
2.修复释放sa时切刀多次释放SA
3.修正伤害计算公式（去除了不稳定的攻击冷却影响）
4.添加可配置内容：拔刀剑伤害系数(影响所有拔刀能造成的伤害)、拔刀锻造系数(影响满足评分后每级锻造增加的伤害)、耀偏方三八面魂的最大可锻造次数
5.修复面板属性额外多一点的问题