### PR TITLE
修正公式后SA数值过高或过低

### DIFF
--- a/src/main/java/mods/flammpfeil/slashblade/ability/ArrowReflector.java
+++ b/src/main/java/mods/flammpfeil/slashblade/ability/ArrowReflector.java
@@ -56,11 +56,9 @@ public class ArrowReflector {
 
             } while (false);
 
-            arrow.setDeltaMovement(dir);
+            ((Projectile) arrow).shoot(dir.x, dir.y, dir.z, 3.5f, 0.2f);
 
-            ((Projectile) arrow).shoot(dir.x, dir.y, dir.z, 1.1f, 0.5f);
-
-            arrow.setNoGravity(true);
+            arrow.setNoGravity(false);
 
             if (arrow instanceof AbstractArrow)
                 ((AbstractArrow) arrow).setCritArrow(true);

--- a/src/main/java/mods/flammpfeil/slashblade/ability/ArrowReflector.java
+++ b/src/main/java/mods/flammpfeil/slashblade/ability/ArrowReflector.java
@@ -58,8 +58,6 @@ public class ArrowReflector {
 
             ((Projectile) arrow).shoot(dir.x, dir.y, dir.z, 3.5f, 0.2f);
 
-            arrow.setNoGravity(false);
-
             if (arrow instanceof AbstractArrow)
                 ((AbstractArrow) arrow).setCritArrow(true);
 

--- a/src/main/java/mods/flammpfeil/slashblade/ability/SummonedSwordArts.java
+++ b/src/main/java/mods/flammpfeil/slashblade/ability/SummonedSwordArts.java
@@ -135,6 +135,7 @@ public class SummonedSwordArts {
                                 state.setProudSoulCount(
                                         state.getProudSoulCount() - SlashBladeConfig.SUMMON_SWORD_ART_COST.get());
 
+                                //圆环幻影剑
                                 AdvancementHelper.grantCriterion(entity, ADVANCEMENT_SPIRAL_SWORDS);
 
                                 Level worldIn = entity.level();
@@ -151,9 +152,7 @@ public class SummonedSwordArts {
                                 for (int i = 0; i < count; i++) {
                                     EntitySpiralSwords ss = new EntitySpiralSwords(
                                             SlashBlade.RegistryEvents.SpiralSwords, worldIn);
-                                    
-                                    worldIn.addFreshEntity(ss);
-
+                                    ss.setPos(entity.position());
                                     ss.setOwner(entity);
                                     ss.setColor(state.getColorCode());
                                     ss.setRoll(0);
@@ -162,6 +161,8 @@ public class SummonedSwordArts {
                                     ss.startRiding(entity, true);
 
                                     ss.setDelay(360 / count * i);
+
+                                    worldIn.addFreshEntity(ss);
 
                                     entity.playNotifySound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 0.2F,
                                             1.45F);
@@ -197,11 +198,12 @@ public class SummonedSwordArts {
                             Level worldIn = entity.level();
                             Entity target = state.getTargetEntity(worldIn);
 
+                            if (target == null || !target.isAlive() || target.isRemoved()) return;
                             if (state.getProudSoulCount() < SlashBladeConfig.SUMMON_SWORD_ART_COST.get())
                                 return;
                             state.setProudSoulCount(
                                     state.getProudSoulCount() - SlashBladeConfig.SUMMON_SWORD_ART_COST.get());
-
+                            //烈风环影剑
                             AdvancementHelper.grantCriterion(entity, ADVANCEMENT_STORM_SWORDS);
 
                             int rank = entity.getCapability(CapabilityConcentrationRank.RANK_POINT)
@@ -217,16 +219,15 @@ public class SummonedSwordArts {
                                 EntityStormSwords ss = new EntityStormSwords(SlashBlade.RegistryEvents.StormSwords,
                                         worldIn);
 
-                                worldIn.addFreshEntity(ss);
-
+                                ss.setPos(entity.position());
                                 ss.setOwner(entity);
                                 ss.setColor(state.getColorCode());
                                 ss.setRoll(0);
                                 ss.setDamage(powerLevel);
                                 // force riding
                                 ss.startRiding(target, true);
-
                                 ss.setDelay(360 / count * i);
+                                worldIn.addFreshEntity(ss);
 
                                 entity.playNotifySound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 0.2F,
                                         1.45F);
@@ -264,7 +265,7 @@ public class SummonedSwordArts {
                                 return;
                             state.setProudSoulCount(
                                     state.getProudSoulCount() - SlashBladeConfig.SUMMON_SWORD_ART_COST.get());
-
+                            //急袭幻影剑
                             AdvancementHelper.grantCriterion(entity, ADVANCEMENT_BLISTERING_SWORDS);
 
                             int rank = entity.getCapability(CapabilityConcentrationRank.RANK_POINT)
@@ -280,8 +281,7 @@ public class SummonedSwordArts {
                                 EntityBlisteringSwords ss = new EntityBlisteringSwords(
                                         SlashBlade.RegistryEvents.BlisteringSwords, worldIn);
 
-                                worldIn.addFreshEntity(ss);
-
+                                ss.setPos(entity.position());
                                 ss.setOwner(entity);
                                 ss.setColor(state.getColorCode());
                                 ss.setRoll(0);
@@ -290,6 +290,8 @@ public class SummonedSwordArts {
                                 ss.startRiding(entity, true);
 
                                 ss.setDelay(i);
+
+                                worldIn.addFreshEntity(ss);
 
                                 entity.playNotifySound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 0.2F,
                                         1.45F);
@@ -328,6 +330,7 @@ public class SummonedSwordArts {
                             state.setProudSoulCount(
                                     state.getProudSoulCount() - SlashBladeConfig.SUMMON_SWORD_ART_COST.get());
 
+                            //五月雨
                             AdvancementHelper.grantCriterion(entity, ADVANCEMENT_HEAVY_RAIN_SWORDS);
 
                             int rank = entity.getCapability(CapabilityConcentrationRank.RANK_POINT)
@@ -349,8 +352,6 @@ public class SummonedSwordArts {
                                 EntityHeavyRainSwords ss = new EntityHeavyRainSwords(
                                         SlashBlade.RegistryEvents.HeavyRainSwords, worldIn);
 
-                                worldIn.addFreshEntity(ss);
-
                                 ss.setOwner(entity);
                                 ss.setColor(state.getColorCode());
                                 ss.setRoll(0);
@@ -363,6 +364,8 @@ public class SummonedSwordArts {
                                 ss.setPos(basePos);
 
                                 ss.setXRot(-90);
+
+                                worldIn.addFreshEntity(ss);
                             }
 
                             int count = 9 + Math.min(rank - 1, 0);
@@ -371,8 +374,6 @@ public class SummonedSwordArts {
                                 for (int l = 0; l < multiplier; l++) {
                                     EntityHeavyRainSwords ss = new EntityHeavyRainSwords(
                                             SlashBlade.RegistryEvents.HeavyRainSwords, worldIn);
-
-                                    worldIn.addFreshEntity(ss);
 
                                     ss.setOwner(entity);
                                     ss.setColor(state.getColorCode());
@@ -386,6 +387,8 @@ public class SummonedSwordArts {
                                     ss.setSpread(basePos);
 
                                     ss.setXRot(-90);
+
+                                    worldIn.addFreshEntity(ss);
 
                                     entity.playNotifySound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 0.2F,
                                             1.45F);
@@ -401,7 +404,7 @@ public class SummonedSwordArts {
                 if (state.getProudSoulCount() < SlashBladeConfig.SUMMON_SWORD_COST.get())
                     return;
                 state.setProudSoulCount(state.getProudSoulCount() - SlashBladeConfig.SUMMON_SWORD_COST.get());
-
+                //幻影剑
                 AdvancementHelper.grantCriterion(sender, ADVANCEMENT_SUMMONEDSWORDS);
 
                 Optional<Entity> foundTarget = findTarget(sender, state.getTargetEntity(sender.level()));
@@ -422,8 +425,6 @@ public class SummonedSwordArts {
                 EntityAbstractSummonedSword ss = new EntityAbstractSummonedSword(
                         SlashBlade.RegistryEvents.SummonedSword, worldIn);
 
-                worldIn.addFreshEntity(ss);
-
                 Vec3 pos = sender.getEyePosition(1.0f)
                         .add(VectorHelper.getVectorForRotation(0.0f, sender.getViewYRot(0) + 90).scale(sided ? 1 : -1));
                 ss.setPos(pos.x, pos.y, pos.z);
@@ -434,6 +435,7 @@ public class SummonedSwordArts {
                 ss.setOwner(sender);
                 ss.setColor(state.getColorCode());
                 ss.setRoll(sender.getRandom().nextFloat() * 360.0f);
+                worldIn.addFreshEntity(ss);
 
                 sender.playNotifySound(SoundEvents.CHORUS_FRUIT_TELEPORT, SoundSource.PLAYERS, 0.2F, 1.45F);
             });

--- a/src/main/java/mods/flammpfeil/slashblade/entity/EntityJudgementCut.java
+++ b/src/main/java/mods/flammpfeil/slashblade/entity/EntityJudgementCut.java
@@ -215,7 +215,7 @@ public class EntityJudgementCut extends Projectile implements IShootable {
             // cyclehit
             if (this.tickCount % 2 == 0) {
                 KnockBacks knockBackType = getIsCritical() ? KnockBacks.toss : KnockBacks.cancel;
-                AttackManager.areaAttack(this, knockBackType.action, 4.0, this.doCycleHit(), false);
+                AttackManager.areaAttack(this, knockBackType.action, 4.0, true, false,0.16f,null);
             }
 
             final int count = 3;

--- a/src/main/java/mods/flammpfeil/slashblade/registry/ComboStateRegistry.java
+++ b/src/main/java/mods/flammpfeil/slashblade/registry/ComboStateRegistry.java
@@ -1061,7 +1061,7 @@ public class ComboStateRegistry {
             ComboState.Builder.newInstance().startAndEnd(1816, 1859).speed(6F).priority(50)
                     .next((entity) -> SlashBlade.prefix("sakura_end_right"))
                     .nextOfTimeout(entity -> SlashBlade.prefix("sakura_end_right"))
-                    .clickAction((entityIn) -> SakuraEnd.doSlash(entityIn, 22.5F, Vec3.ZERO, false, false, 1.2))
+                    .clickAction((entityIn) -> SakuraEnd.doSlash(entityIn, 22.5F, Vec3.ZERO, false, false, 0.5))
                     .addTickAction((entityIn) -> UserPoseOverrider.resetRot(entityIn))
                     .addHitEffect(StunManager::setStun)::build);
 
@@ -1069,7 +1069,7 @@ public class ComboStateRegistry {
             ComboState.Builder.newInstance().startAndEnd(204, 218).speed(1.1F).priority(50)
                     .next((entity) -> SlashBlade.prefix("none"))
                     .nextOfTimeout(entity -> SlashBlade.prefix("sakura_end_finish"))
-                    .clickAction((entityIn) -> SakuraEnd.doSlash(entityIn, 180F - 22.5F, Vec3.ZERO, false, true, 1.5))
+                    .clickAction((entityIn) -> SakuraEnd.doSlash(entityIn, 180F - 22.5F, Vec3.ZERO, false, true, 0.76))
                     .addTickAction((entityIn) -> UserPoseOverrider.resetRot(entityIn))
                     .addHitEffect((t, a) -> StunManager.setStun(t, 36))::build);
 
@@ -1088,7 +1088,7 @@ public class ComboStateRegistry {
             ComboState.Builder.newInstance().startAndEnd(1300, 1328).speed(3.2F).priority(50)
                     .next((entity) -> SlashBlade.prefix("sakura_end_right_air"))
                     .nextOfTimeout(entity -> SlashBlade.prefix("sakura_end_right_air"))
-                    .clickAction((entityIn) -> SakuraEnd.doSlash(entityIn, 22.5F, Vec3.ZERO, false, false, 1.2))
+                    .clickAction((entityIn) -> SakuraEnd.doSlash(entityIn, 22.5F, Vec3.ZERO, false, false, 0.5))
                     .addTickAction((entityIn) -> UserPoseOverrider.resetRot(entityIn))
                     .addTickAction(FallHandler::fallDecrease).addHitEffect(StunManager::setStun).aerial()::build);
 
@@ -1096,7 +1096,7 @@ public class ComboStateRegistry {
             ComboState.Builder.newInstance().startAndEnd(1200, 1210).priority(50)
                     .next((entity) -> SlashBlade.prefix("none"))
                     .nextOfTimeout(entity -> SlashBlade.prefix("sakura_end_finish_air"))
-                    .clickAction((entityIn) -> SakuraEnd.doSlash(entityIn, 180F - 22.5F, Vec3.ZERO, false, true, 1.5))
+                    .clickAction((entityIn) -> SakuraEnd.doSlash(entityIn, 180F - 22.5F, Vec3.ZERO, false, true, 0.76))
                     .addTickAction((entityIn) -> UserPoseOverrider.resetRot(entityIn))
                     .addTickAction(FallHandler::fallDecrease).addHitEffect(StunManager::setStun).aerial()::build);
 
@@ -1148,7 +1148,7 @@ public class ComboStateRegistry {
                     .next(ComboState.TimeoutNext.buildFromFrame(15, entity -> SlashBlade.prefix("none")))
                     .nextOfTimeout(entity -> SlashBlade.prefix("drive_horizontal_end"))
                     .addTickAction(ComboState.TimeLineTickAction.getBuilder()
-                            .put(2, (entityIn) -> AttackManager.doSlash(entityIn, -30F, Vec3.ZERO, false, false, 0.1F))
+                            .put(2, (entityIn) -> AttackManager.doSlash(entityIn, -30F, Vec3.ZERO, false, false, 0.21F))
                             .put(3, (entityIn) -> Drive.doSlash(entityIn, 0F, 10, Vec3.ZERO, false, 1.5f, 2f)).build())
                     .addHitEffect(StunManager::setStun)
                     ::build);
@@ -1168,7 +1168,7 @@ public class ComboStateRegistry {
             .next(ComboState.TimeoutNext.buildFromFrame(15, entity -> SlashBlade.prefix("none")))
             .nextOfTimeout(entity -> SlashBlade.prefix("drive_vertical_end"))
             .addTickAction(ComboState.TimeLineTickAction.getBuilder()
-                    .put(2, (entityIn) -> AttackManager.doSlash(entityIn, -80F, Vec3.ZERO, false, false, 0.1F))
+                    .put(2, (entityIn) -> AttackManager.doSlash(entityIn, -80F, Vec3.ZERO, false, false, 0.21F))
                     .put(3, (entityIn) -> Drive.doSlash(entityIn, -90F, 10, Vec3.ZERO, false, 1.5f, 2f)).build())
             .addHitEffect(StunManager::setStun)
             ::build
@@ -1193,8 +1193,8 @@ public class ComboStateRegistry {
             .next(ComboState.TimeoutNext.buildFromFrame(15, entity -> SlashBlade.prefix("none")))
             .nextOfTimeout(entity -> SlashBlade.prefix("drive_vertical_end"))
             .addTickAction(ComboState.TimeLineTickAction.getBuilder()
-                     .put(2, (entityIn) -> AttackManager.doSlash(entityIn, -80F, Vec3.ZERO, false, false, 0.1F))
-                     .put(3, (entityIn) -> WaveEdge.doSlash(entityIn, 90F, 20, Vec3.ZERO, false, 0.5F, 0.2f, 1f, 4)).build())
+                     .put(2, (entityIn) -> AttackManager.doSlash(entityIn, -80F, Vec3.ZERO, false, false, 0.21F))
+                     .put(3, (entityIn) -> WaveEdge.doSlash(entityIn, 90F, 20, Vec3.ZERO, false, 0.4F, 0.2f, 1f, 4)).build())
             .addHitEffect(StunManager::setStun)
             ::build
     );
@@ -1231,7 +1231,7 @@ public class ComboStateRegistry {
                 if (elapsed < 3) {
                     if (entity.onGround())
                     	entity.moveRelative(entity.isInWater() ? 0.35f : 0.8f, new Vec3(0, 0, 1));
-                    AttackManager.areaAttack(entity, KnockBacks.toss.action, 1.1f, true, false, true);
+                    AttackManager.areaAttack(entity, KnockBacks.toss.action, 1.01f, true, false, true);
                 } 
                 if(elapsed == 1)
                 	AttackManager.playPiercingSoundAction(entity);
@@ -1250,7 +1250,7 @@ public class ComboStateRegistry {
                 if (elapsed < 3) {
                     if (entity.onGround())
                         entity.moveRelative(entity.isInWater() ? 0.35f : 0.8f, new Vec3(0, 0, 1));
-                    AttackManager.areaAttack(entity, KnockBacks.toss.action, 1.1f, true, false, true);
+                    AttackManager.areaAttack(entity, KnockBacks.toss.action, 1.01f, true, false, true);
                 } 
                 if(elapsed == 1)
                 	AttackManager.playPiercingSoundAction(entity);

--- a/src/main/java/mods/flammpfeil/slashblade/slasharts/CircleSlash.java
+++ b/src/main/java/mods/flammpfeil/slashblade/slasharts/CircleSlash.java
@@ -44,7 +44,7 @@ public class CircleSlash {
         jc.setMute(false);
         jc.setIsCritical(true);
 
-        jc.setDamage(1D);
+        jc.setDamage(0.325D);
 
         jc.setKnockBack(KnockBacks.cancel);
 

--- a/src/main/java/mods/flammpfeil/slashblade/util/AttackManager.java
+++ b/src/main/java/mods/flammpfeil/slashblade/util/AttackManager.java
@@ -156,12 +156,28 @@ public class AttackManager {
                                         (double) (-Math.sin(yRot * (float) Math.PI / 180.0F) * 0.5),
                                         0.05D,
                                         (double) (Math.cos(yRot * (float) Math.PI / 180.0F) * 0.5)));
-                                float scale = 1f;
+                                double baseAmount = living.getAttributeValue(Attributes.ATTACK_DAMAGE);
+                                int powerLevel = living.getMainHandItem().getEnchantmentLevel(Enchantments.POWER_ARROWS);
+                                baseAmount *= (1 + (float) powerLevel * 0.1F);
+                                //评分等级加成
+                                if (living instanceof Player player){
+                                    IConcentrationRank.ConcentrationRanks rankBonus = player
+                                            .getCapability(ConcentrationRankCapabilityProvider.RANK_POINT)
+                                            .map(rp -> rp.getRank(player.getCommandSenderWorld().getGameTime()))
+                                            .orElse(IConcentrationRank.ConcentrationRanks.NONE);
+                                    float rankDamageBonus = rankBonus.level / 2.0f;
+                                    if (IConcentrationRank.ConcentrationRanks.S.level <= rankBonus.level) {
+                                        int refine = player.getMainHandItem().getCapability(ItemSlashBlade.BLADESTATE).map(rp -> rp.getRefine()).orElse(0);
+                                        int level = player.experienceLevel;
+                                        rankDamageBonus = (float) Math.max(rankDamageBonus, Math.min(level, refine) * REFINE_DAMAGE_MULTIPLIER.get());
+                                    }
+                                    baseAmount += rankDamageBonus;
+                                }
                                 if (this.getShooter() instanceof LivingEntity shooter){
-                                    scale = (float) (getSlashBladeDamageScale(shooter) * SLASHBLADE_DAMAGE_MULTIPLIER.get());
+                                    baseAmount *= getSlashBladeDamageScale(shooter) * SLASHBLADE_DAMAGE_MULTIPLIER.get();
                                 }
                                 doAttackWith(this.damageSources().indirectMagic(this, this.getShooter()),
-                                        (float) (living.getAttributeValue(Attributes.ATTACK_DAMAGE) * 2F * scale), entity, true,
+                                        ((float) (baseAmount) * 5.1f), entity, true,
                                         true);
                             }
                         });
@@ -233,7 +249,13 @@ public class AttackManager {
     }
 
     static public <E extends Entity & IShootable> List<Entity> areaAttack(E owner, Consumer<LivingEntity> beforeHit,
-            double reach, boolean forceHit, boolean resetHit, List<Entity> exclude) {
+                                                                          double reach, boolean forceHit, boolean resetHit, List<Entity> exclude) {
+
+        return areaAttack(owner, beforeHit, reach, forceHit, resetHit, 1.0F, exclude);
+    }
+
+    static public <E extends Entity & IShootable> List<Entity> areaAttack(E owner, Consumer<LivingEntity> beforeHit,
+            double reach, boolean forceHit, boolean resetHit, float comboRatio, List<Entity> exclude) {
         List<Entity> founds = Lists.newArrayList();
 
         // AABB bb = owner.getBoundingBox();
@@ -256,7 +278,23 @@ public class AttackManager {
 	                	int powerLevel = living.getMainHandItem().getEnchantmentLevel(Enchantments.POWER_ARROWS);
 	                	baseAmount += ((float) powerLevel * 0.1F);
                 	}
-                	baseAmount *= living.getAttributeValue(Attributes.ATTACK_DAMAGE) * getSlashBladeDamageScale(living) * SLASHBLADE_DAMAGE_MULTIPLIER.get();
+                    baseAmount *= living.getAttributeValue(Attributes.ATTACK_DAMAGE);
+                    //评分等级加成
+                    if (owner instanceof Player player){
+                        IConcentrationRank.ConcentrationRanks rankBonus = player
+                                .getCapability(ConcentrationRankCapabilityProvider.RANK_POINT)
+                                .map(rp -> rp.getRank(player.getCommandSenderWorld().getGameTime()))
+                                .orElse(IConcentrationRank.ConcentrationRanks.NONE);
+                        float rankDamageBonus = rankBonus.level / 2.0f;
+                        if (IConcentrationRank.ConcentrationRanks.S.level <= rankBonus.level) {
+                            int refine = player.getMainHandItem().getCapability(ItemSlashBlade.BLADESTATE).map(rp -> rp.getRefine()).orElse(0);
+                            int level = player.experienceLevel;
+                            rankDamageBonus = (float) Math.max(rankDamageBonus, Math.min(level, refine) * REFINE_DAMAGE_MULTIPLIER.get());
+                        }
+                        baseAmount += rankDamageBonus;
+                    }
+
+                	baseAmount *= comboRatio * getSlashBladeDamageScale(living) * SLASHBLADE_DAMAGE_MULTIPLIER.get();
 
                 }
 

--- a/src/main/java/mods/flammpfeil/slashblade/util/TargetSelector.java
+++ b/src/main/java/mods/flammpfeil/slashblade/util/TargetSelector.java
@@ -39,7 +39,7 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.targeting.TargetingConditions;
 
 public class TargetSelector {
-	static public final TargetingConditions lockon = new SlashBladeTargetingConditions().range(12.0D)
+	static public final TargetingConditions lockon = new SlashBladeTargetingConditions().range(40.0D)
 			.selector(new AttackablePredicate());
 
 	static public final TargetingConditions test = new SlashBladeTargetingConditions()


### PR DESCRIPTION
1.去除了幻影刃类SA的异常多次挥刀伤害（改为一次并上调伤害与ComboA单次伤害一致）
2.为所有SA添加了评分等级伤害增幅，并下调了除虚无刀界外的SA的数值。
3.反弹的投射物会受到重力影响，但增加了初始速度并增加了精准度。（用于修复#55）
4.上调极限锁定距离为40（原12，但在LockOnManager.java中本身瞄准索敌的极限距离是40格）










































































