### PR TITLE
添加不能掉落破碎耀魂的附魔配置选项

### DIFF
--- a/src/main/java/mods/flammpfeil/slashblade/SlashBladeConfig.java
+++ b/src/main/java/mods/flammpfeil/slashblade/SlashBladeConfig.java
@@ -1,6 +1,9 @@
 package mods.flammpfeil.slashblade;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraftforge.common.ForgeConfigSpec;
+
+import java.util.List;
 
 public class SlashBladeConfig {
     public static ForgeConfigSpec COMMON_CONFIG;
@@ -19,6 +22,7 @@ public class SlashBladeConfig {
     public static ForgeConfigSpec.DoubleValue REFINE_DAMAGE_MULTIPLIER;
     public static ForgeConfigSpec.IntValue TRAPEZOHEDRON_MAX_REFINE;
 
+    public static ForgeConfigSpec.ConfigValue<List<? extends String>> NON_DROPPABLE_ENCHANTMENT;
     
     static {
         ForgeConfigSpec.Builder COMMON_BUILDER = new ForgeConfigSpec.Builder();
@@ -60,6 +64,9 @@ public class SlashBladeConfig {
 
         TRAPEZOHEDRON_MAX_REFINE = COMMON_BUILDER.comment("The maximum number of refine of Trapezohedron.[Default: 2147483647(infinity)]")
                 .defineInRange("trapezohedron_max_refine", Integer.MAX_VALUE, 200, Integer.MAX_VALUE);
+
+        NON_DROPPABLE_ENCHANTMENT = COMMON_BUILDER.comment("Example: 'minecraft:sharpness', That will prevent the enchantment from dropping the corresponding proudsoul tiny.")
+                .defineList("non-droppable_enchantments", new ObjectArrayList<>(), o -> o instanceof String);
 
         COMMON_BUILDER.pop();
         COMMON_CONFIG = COMMON_BUILDER.build();

--- a/src/main/java/mods/flammpfeil/slashblade/item/ItemSlashBlade.java
+++ b/src/main/java/mods/flammpfeil/slashblade/item/ItemSlashBlade.java
@@ -251,14 +251,20 @@ public class ItemSlashBlade extends SwordItem {
 			if (stack.isEnchanted()) {
 				int count = Math.max(1, state.getProudSoulCount() / 1000);
 				List<Enchantment> enchantments = ForgeRegistries.ENCHANTMENTS.getValues().stream()
-						.filter(enchantment -> stack.canApplyAtEnchantingTable(enchantment)).toList();
+						.filter(enchantment -> stack.canApplyAtEnchantingTable(enchantment))
+						.filter(enchantment ->
+								!SlashBladeConfig.NON_DROPPABLE_ENCHANTMENT.get().contains(ForgeRegistries.ENCHANTMENTS.getKey(enchantment).toString()))
+						.toList();
 				for (int i = 0; i < count; i += 1) {
 					ItemStack enchanted_soul = new ItemStack(SBItems.proudsoul_tiny);
-					enchanted_soul.enchant(enchantments.get(user.getRandom().nextInt(0, enchantments.size())), 1);
-					ItemEntity itemEntity = new ItemEntity(user.level(), user.getX(), user.getY(), user.getZ(),
-							enchanted_soul);
-					itemEntity.setDefaultPickUpDelay();
-					user.level().addFreshEntity(itemEntity);
+					Enchantment enchant = enchantments.get(user.getRandom().nextInt(0, enchantments.size()));
+					if (enchant != null){
+						enchanted_soul.enchant(enchant, 1);
+						ItemEntity itemEntity = new ItemEntity(user.level(), user.getX(), user.getY(), user.getZ(),
+								enchanted_soul);
+						itemEntity.setDefaultPickUpDelay();
+						user.level().addFreshEntity(itemEntity);
+					}
 				}
 			}
 			ItemStack soul = new ItemStack(SBItems.proudsoul_tiny);


### PR DESCRIPTION
添加不能掉落破碎耀魂的附魔配置选项
示例：non-droppable_enchantments = ["minecraft:aqua_affinity", "minecraft:bane_of_arthropods"]