### PR TITLE
移除FTB Quests依赖，使开发环境能够执行runClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,10 +197,10 @@ dependencies {
 	//runtimeOnly fg.deobf("dev.emi:emi-forge:${emi_version}") 
 	
 	//FTB Quests
-    implementation fg.deobf("curse.maven:ftb-quests-forge-289412:6167056")
-    implementation fg.deobf("curse.maven:ftb-library-forge-404465:6164053")
-    implementation fg.deobf("curse.maven:ftb-teams-forge-404468:6130786")
-    implementation fg.deobf("curse.maven:item-filters-309674:4838266")
+//    implementation fg.deobf("curse.maven:ftb-quests-forge-289412:6431737")
+//    implementation fg.deobf("curse.maven:ftb-library-forge-404465:6164053")
+//    implementation fg.deobf("curse.maven:ftb-teams-forge-404468:6130786")
+//    implementation fg.deobf("curse.maven:item-filters-309674:4838266")
 }
 
 tasks.named('processResources', ProcessResources).configure {


### PR DESCRIPTION
定位开发环境无法runClient的问题出现在1.2.32，1.2.31是最后一个能正常runClient的提交。两者对比，仅有对build.gradle的修改，会涉及到构建。已经尝试过把implementation替换成runtimeOnly，也不奏效。只要删除这四个依赖，就能正常构建。不确定这四个依赖有什么问题，可能有待向FTB方面反馈。