### PR TITLE
fix: prevent NPE in EntityAbstractSummonedSword when TargetSelector rejects a target

### DIFF
--- a/src/main/java/mods/flammpfeil/slashblade/entity/EntityAbstractSummonedSword.java
+++ b/src/main/java/mods/flammpfeil/slashblade/entity/EntityAbstractSummonedSword.java
@@ -460,7 +460,6 @@ public class EntityAbstractSummonedSword extends Projectile implements IShootabl
 
     @Override
     protected void onHit(HitResult raytraceResultIn) {
-        if (raytraceResultIn == null) return;
         HitResult.Type type = raytraceResultIn.getType();
         switch (type) {
             case ENTITY:

--- a/src/main/java/mods/flammpfeil/slashblade/entity/EntityAbstractSummonedSword.java
+++ b/src/main/java/mods/flammpfeil/slashblade/entity/EntityAbstractSummonedSword.java
@@ -375,6 +375,8 @@ public class EntityAbstractSummonedSword extends Projectile implements IShootabl
                     }
                 }
 
+                if (raytraceresult == null)
+                    break;
                 if (!(disallowedHitBlock && raytraceresult.getType() == HitResult.Type.BLOCK)
                         && impactCheck) {
                     this.onHit(raytraceresult);

--- a/src/main/java/mods/flammpfeil/slashblade/entity/EntityAbstractSummonedSword.java
+++ b/src/main/java/mods/flammpfeil/slashblade/entity/EntityAbstractSummonedSword.java
@@ -460,6 +460,7 @@ public class EntityAbstractSummonedSword extends Projectile implements IShootabl
 
     @Override
     protected void onHit(HitResult raytraceResultIn) {
+        if (raytraceResultIn == null) return;
         HitResult.Type type = raytraceResultIn.getType();
         switch (type) {
             case ENTITY:


### PR DESCRIPTION
本PR尝试修复一个在使用幻影剑时潜在的会导致服务端与客户端同时崩溃，且无法正常恢复的恶性NPE Bug

服务端崩溃恢复方法：
修改world/serverconfig/forge-server.toml

removeErroringBlockEntities = true
removeErroringEntities = true

服务端崩溃日志如下：
```log
---- Minecraft Crash Report ---- // Daisy, daisy...

Time: 2026-05-11 15:14:54 Description: Ticking entity

java.lang.NullPointerException: Cannot invoke
"net.minecraft.world.phys.HitResult.m_6662_()" because "raytraceResultIn" is
null at
mods.flammpfeil.slashblade.entity.EntityAbstractSummonedSword.m_6532_(EntityAbstractSummonedSword.java:463)
~[SlashBladeResharped-1.20.1-1.9.64.jar%23171!/:1.9.64]
{re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:A,pl:runtimedistcleaner:A}
at
mods.flammpfeil.slashblade.entity.EntityAbstractSummonedSword.m_8119_(EntityAbstractSummonedSword.java:380)
~[SlashBladeResharped-1.20.1-1.9.64.jar%23171!/:1.9.64]
{re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:A,pl:runtimedistcleaner:A}
at
mods.flammpfeil.slashblade.ability.SlayerStyleArts$1.m_8119_(SlayerStyleArts.java:297)
~[SlashBladeResharped-1.20.1-1.9.64.jar%23171!/:1.9.64] {re:classloading} at
net.minecraft.server.level.ServerLevel.m_8647_(ServerLevel.java:694)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.world.level.Level.m_46653_(Level.java:479)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:botania_xplat.mixins.json:LevelAccessor,pl:mixin:APP:mixins.hammerlib.json:LevelMixin,pl:mixin:APP:kubejs-common.mixins.json:LevelMixin,pl:mixin:A}
at net.minecraft.server.level.ServerLevel.m_184063_(ServerLevel.java:343)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at
net.minecraft.world.level.entity.EntityTickList.m_156910_(EntityTickList.java:54)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?] {re:classloading} at
net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:323)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:893)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at
net.minecraft.server.dedicated.DedicatedServer.m_5703_(DedicatedServer.java:283)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:worldedithangfix.mixins.json:DedicatedServerMixin,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:814)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:661)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:251)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at java.lang.Thread.run(Unknown Source) ~[?:?] {re:mixin}

A detailed walkthrough of the error, its code path and all known details is as follows:

-- Head -- Thread: Server thread Suspected Mod: Slash Blade:Resharped
(slashblade), Version: 1.9.64 at
TRANSFORMER/slashblade@1.9.64/mods.flammpfeil.slashblade.entity.EntityAbstractSummonedSword.m_6532_(EntityAbstractSummonedSword.java:463)
Stacktrace: at
mods.flammpfeil.slashblade.entity.EntityAbstractSummonedSword.m_6532_(EntityAbstractSummonedSword.java:463)
~[SlashBladeResharped-1.20.1-1.9.64.jar%23171!/:1.9.64]
{re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:A,pl:runtimedistcleaner:A}
at
mods.flammpfeil.slashblade.entity.EntityAbstractSummonedSword.m_8119_(EntityAbstractSummonedSword.java:380)
~[SlashBladeResharped-1.20.1-1.9.64.jar%23171!/:1.9.64]
{re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:A,pl:runtimedistcleaner:A}
at
mods.flammpfeil.slashblade.ability.SlayerStyleArts$1.m_8119_(SlayerStyleArts.java:297)
~[SlashBladeResharped-1.20.1-1.9.64.jar%23171!/:1.9.64] {re:classloading} at
net.minecraft.server.level.ServerLevel.m_8647_(ServerLevel.java:694)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.world.level.Level.m_46653_(Level.java:479)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:botania_xplat.mixins.json:LevelAccessor,pl:mixin:APP:mixins.hammerlib.json:LevelMixin,pl:mixin:APP:kubejs-common.mixins.json:LevelMixin,pl:mixin:A}
at net.minecraft.server.level.ServerLevel.m_184063_(ServerLevel.java:343)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at
net.minecraft.world.level.entity.EntityTickList.m_156910_(EntityTickList.java:54)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?] {re:classloading} at
net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:323)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
-- Entity being ticked -- Details: Entity Type:
slashblade:abstract_summoned_sword (null) Entity ID: 72692 Entity Name:
entity.slashblade.abstract_summoned_sword Entity's Exact
location: 115.93, 74.76, 239.66 Entity's Block location: World: (115,74,239),
Section: (at 3,10,15 in 7,4,14; chunk contains blocks 112,0,224 to 127,255,239),
Region: (0,0; contains chunks 0,0 to 31,31, blocks 0,0,0 to 511,255,511)
Entity's Momentum: 0.22, -0.96, 0.09 Entity's Passengers: [] Entity's Vehicle:
null Stacktrace: at net.minecraft.world.level.Level.m_46653_(Level.java:479)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:botania_xplat.mixins.json:LevelAccessor,pl:mixin:APP:mixins.hammerlib.json:LevelMixin,pl:mixin:APP:kubejs-common.mixins.json:LevelMixin,pl:mixin:A}
at net.minecraft.server.level.ServerLevel.m_184063_(ServerLevel.java:343)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at
net.minecraft.world.level.entity.EntityTickList.m_156910_(EntityTickList.java:54)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?] {re:classloading} at
net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:323)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:893)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at
net.minecraft.server.dedicated.DedicatedServer.m_5703_(DedicatedServer.java:283)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:worldedithangfix.mixins.json:DedicatedServerMixin,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:814)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:661)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:251)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at java.lang.Thread.run(Unknown Source) ~[?:?] {re:mixin}

-- Affected level -- Details: All players: 1 total;
[ServerPlayer['KazihaAkaze'/49875, l='ServerLevel[world]', x=115.57, y=75.40,
z=239.48]] Chunk stats: 2401 Level dimension: minecraft:the_nether Derived: true
Level spawn location: World: (176,82,208), Section: (at 0,2,0 in 11,5,13; chunk
contains blocks 176,0,208 to 191,255,223), Region: (0,0; contains chunks 0,0
to 31,31, blocks 0,0,0 to 511,255,511) Level time: 2068762 game time, 1730749
day time Level name: world Level game mode: Game mode: survival (ID 0).
Hardcore: false. Cheats: false Level weather: Rain time: 78870 (now: false),
thunder time: 99157 (now: false) Known server brands: forge Removed feature
flags: Level was modded: true Level storage version: 0x04ABD - Anvil Stacktrace:
at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:893)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at
net.minecraft.server.dedicated.DedicatedServer.m_5703_(DedicatedServer.java:283)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:worldedithangfix.mixins.json:DedicatedServerMixin,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:814)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:661)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:251)
~[server-1.20.1-20230612.114412-srg.jar%23185!/:?]
{re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at java.lang.Thread.run(Unknown Source) ~[?:?] {re:mixin}

-- System Details -- Details: Minecraft Version: 1.20.1 Minecraft Version
ID: 1.20.1 Operating System: Linux (amd64) version 5.14.0-611.5.1.el9_7.x86_64
Java Version: 25.0.3, Eclipse Adoptium Java VM Version: OpenJDK 64-Bit Server VM
(mixed mode, sharing), Eclipse Adoptium Memory: 2648386488 bytes (2525 MiB)
/ 8589934592 bytes (8192 MiB) up to 8589934592 bytes (8192 MiB) CPUs: 16
Processor Vendor: GenuineIntel Processor Name: INTEL(R) XEON(R) GOLD 6530
Identifier: Intel64 Family 6 Model 207 Stepping 2 Microarchitecture: unknown
Frequency (GHz): -0.00 Number of physical packages: 1 Number of physical
CPUs: 16 Number of logical CPUs: 16 Graphics card #0 name: unknown Graphics card
#0 vendor: unknown Graphics card #0 VRAM (MB): 0.00 Graphics card #0 deviceId:
unknown Graphics card #0 versionInfo: unknown Virtual memory max (MB): 31269.86
Virtual memory used (MB): 11283.40 Swap memory total (MB): 15732.00 Swap memory
used (MB): 0.00 JVM Flags: 3 total; -Xmx8G -Xms8G -XX:+UseG1GC Server Running:
true Player Count: 2 / 20; [ServerPlayer['lazyezzz'/49874,
l='ServerLevel[world]', x=-1496.69, y=71.00, z=-402.57],
ServerPlayer['KazihaAkaze'/49875, l='ServerLevel[world]', x=115.57, y=75.40,
z=239.48]] Data Packs: vanilla, mod:farmersdelight, mod:emi (incompatible),
mod:rhino (incompatible), mod:libipn (incompatible), mod:mousetweaks, mod:jade
(incompatible), mod:truepower, mod:ebwizardry (incompatible), mod:jei,
mod:slashblade, mod:botania, mod:xaerolib (incompatible), mod:hammerlib,
mod:kotlinforforge (incompatible), mod:easy_villagers, mod:sophisticatedcore
(incompatible), mod:touhou_little_maid, mod:curios (incompatible), mod:patchouli
(incompatible), mod:xaerominimap (incompatible), mod:manapeeper (incompatible),
mod:touhou_little_maid_spell, mod:xaeroworldmap (incompatible), mod:modernfix
(incompatible), mod:sbr_core, mod:configured (incompatible),
mod:sophisticatedbackpacks (incompatible), mod:inventoryprofilesnext
(incompatible), mod:architectury (incompatible), mod:kubejs (incompatible),
mod:ferritecore (incompatible), mod:true_power_of_maid, mod:botanicadds
(incompatible), mod:forge, mod:appleskin (incompatible), mod:slashblade_addon,
mod:embeddium, mod:cloth_config (incompatible), mod:sodiumdynamiclights,
mod:chloride, mod:fabric_api_base, mod:worldeditcui (incompatible),
mod:worldedit (incompatible), mod:worldedithangfix (incompatible) Enabled
Feature Flags: minecraft:vanilla World Generation: Experimental Is Modded:
Definitely; Server brand changed to 'forge' Type: Dedicated Server
(map_server.txt) ModLauncher: 10.0.9+10.0.9+main.dcd20f30 ModLauncher launch
target: forgeserver ModLauncher naming: srg ModLauncher services:
mixin-0.8.5.jar mixin PLUGINSERVICE eventbus-6.2.33.jar eventbus PLUGINSERVICE
fmlloader-1.20.1-47.4.20.jar slf4jfixer PLUGINSERVICE
fmlloader-1.20.1-47.4.20.jar object_holder_definalize PLUGINSERVICE
fmlloader-1.20.1-47.4.20.jar runtime_enum_extender PLUGINSERVICE
fmlloader-1.20.1-47.4.20.jar capability_token_subclass PLUGINSERVICE
accesstransformers-8.0.4.jar accesstransformer PLUGINSERVICE
fmlloader-1.20.1-47.4.20.jar runtimedistcleaner PLUGINSERVICE
modlauncher-10.0.9.jar mixin TRANSFORMATIONSERVICE modlauncher-10.0.9.jar fml
TRANSFORMATIONSERVICE modlauncher-10.0.9.jar I18nUpdateMod TRANSFORMATIONSERVICE
FML Language Providers: minecraft@1.0 lowcodefml@null kotlinforforge@4.12.0
javafml@null Mod List: server-1.20.1-20230612.114412-srg.jar |Minecraft
|minecraft |1.20.1 |DONE |Manifest: NOSIGNATURE FarmersDelight-1.20.1-1.3.1.jar
|Farmer's Delight |farmersdelight |1.20.1-1.3.1 |DONE |Manifest: NOSIGNATURE
emi-1.1.22+1.20.1+forge.jar |EMI |emi |1.1.22+1.20.1+forge |DONE |Manifest:
NOSIGNATURE libIPN-forge-1.20-4.0.2.jar |libIPN |libipn |4.0.2 |DONE |Manifest:
NOSIGNATURE rhino-forge-2001.2.3-build.10.jar |Rhino |rhino |2001.2.3-build.10
|DONE |Manifest: NOSIGNATURE fabric-api-base-0.4.31+ef105b4977.jar |Fabric API
Base |fabric_api_base |0.4.31+ef105b4977 |DONE |Manifest: NOSIGNATURE
MouseTweaks-forge-mc1.20.1-2.25.1.jar |Mouse Tweaks |mousetweaks |2.25.1 |DONE
|Manifest: NOSIGNATURE Jade-1.20.1-Forge-11.13.2.jar |Jade |jade |11.13.2+forge
|DONE |Manifest: NOSIGNATURE True_POWER-1.20.1-1.1.7-hotfix1.jar |True POWER
|truepower |1.1.7-hotfix1 |DONE |Manifest: NOSIGNATURE
electroblobs-wizardry-redux-0.8.3-forge.jar |Electroblob's Wizardry Redux
|ebwizardry |0.8.3 |DONE |Manifest: NOSIGNATURE jei-1.20.1-forge-15.20.0.130.jar
|Just Enough Items |jei |15.20.0.130 |DONE |Manifest: NOSIGNATURE
Botania-1.20.1-452-FORGE.jar |Botania |botania |1.20.1-452-FORGE |DONE
|Manifest: NOSIGNATURE SlashBladeResharped-1.20.1-1.9.64.jar |Slash
Blade:Resharped |slashblade |1.9.64 |DONE |Manifest: NOSIGNATURE
xaerolib-forge-1.20.1-1.1.15.jar |XaeroLib |xaerolib |1.1.15 |DONE |Manifest:
NOSIGNATURE HammerLib-1.20.1-20.1.50.jar |HammerLib |hammerlib |20.1.50 |DONE
|Manifest: 97:e8:52:e9:b3:f0:1b:83:57:4e:83:15:f7:e7:76:51:c6:60:5f:2b:45:59:19:a7:31:9e:98:69:56:4f:01:3c
kffmod-4.12.0.jar |Kotlin For Forge |kotlinforforge |4.12.0 |DONE |Manifest:
NOSIGNATURE easy-villagers-forge-1.20.1-1.1.39.jar |Easy Villagers
|easy_villagers |1.20.1-1.1.39 |DONE |Manifest: NOSIGNATURE
sophisticatedcore-1.20.1-1.3.34.1844.jar |Sophisticated Core |sophisticatedcore
|1.3.34.1844 |DONE |Manifest: NOSIGNATURE
touhoulittlemaid-1.5.3-forge+mc1.20.1.jar |Touhou Little Maid
|touhou_little_maid |1.5.3-forge+mc1.20.1|DONE |Manifest: NOSIGNATURE
curios-forge-5.14.1+1.20.1.jar |Curios API |curios |5.14.1+1.20.1 |DONE
|Manifest: NOSIGNATURE Patchouli-1.20.1-85-FORGE.jar |Patchouli |patchouli
|1.20.1-85-FORGE |DONE |Manifest: NOSIGNATURE
xaerominimap-forge-1.20.1-25.3.13.jar |Xaero's Minimap |xaerominimap |25.3.13
|DONE |Manifest: NOSIGNATURE ManaPeeper-1.4+1.20.1-forge.jar |Mana Peeper
|manapeeper |1.4+1.20.1-forge |DONE |Manifest: NOSIGNATURE
touhou_little_maid_spell-1.7.3.8-forge+mc1.20.1.ja|Touhou Little Maid: Spell
|touhou_little_maid_spell |1.7.3.8-forge+mc1.20|DONE |Manifest: NOSIGNATURE
xaeroworldmap-forge-1.20.1-1.40.16.jar |Xaero's World Map |xaeroworldmap
|1.40.16 |DONE |Manifest: NOSIGNATURE modernfix-forge-5.27.22+mc1.20.1.jar
|ModernFix |modernfix |5.27.22+mc1.20.1 |DONE |Manifest: NOSIGNATURE
mrqxs_Slashblade_Core-1.20.1-1.4.1.jar |mrqx`s Slashblade Core |sbr_core |1.4.1
|DONE |Manifest: NOSIGNATURE configured-forge-1.20.1-2.2.3.jar |Configured
|configured |2.2.3 |DONE
|Manifest: 0d:78:5f:44:c0:47:0c:8c:e2:63:a3:04:43:d4:12:7d:b0:7c:35:37:dc:40:b1:c1:98:ec:51:eb:3b:3c:45:99
WorldEditCUI-1.20+01.jar |WorldEditCUI |worldeditcui |1.20+01 |DONE |Manifest:
NOSIGNATURE sophisticatedbackpacks-1.20.1-3.24.38.1738.jar |Sophisticated
Backpacks |sophisticatedbackpacks |3.24.38.1738 |DONE |Manifest: NOSIGNATURE
worldedit-mod-7.2.15.jar |WorldEdit |worldedit |7.2.15+6463-5ca4dff |DONE
|Manifest: NOSIGNATURE InventoryProfilesNext-forge-1.20-1.10.20.jar |Inventory
Profiles Next |inventoryprofilesnext |1.10.20 |DONE |Manifest: NOSIGNATURE
architectury-9.2.14-forge.jar |Architectury |architectury |9.2.14 |DONE
|Manifest: NOSIGNATURE kubejs-forge-2001.6.5-build.26.jar |KubeJS |kubejs
|2001.6.5-build.26 |DONE |Manifest: NOSIGNATURE ferritecore-6.0.1-forge.jar
|Ferrite Core |ferritecore |6.0.1 |DONE
|Manifest: 41:ce:50:66:d1:a0:05:ce:a1:0e:02:85:9b:46:64:e0:bf:2e:cf:60:30:9a:fe:0c:27:e0:63:66:9a:84:ce:8a
True_POWER_of_Maid-1.20.1-1.2.1.jar |True POWER of Maid |true_power_of_maid
|1.2.1 |DONE |Manifest: NOSIGNATURE BotanicAdditions-1.20.1-20.1.3.jar |Botanic
Additions |botanicadds |20.1.3 |DONE
|Manifest: 97:e8:52:e9:b3:f0:1b:83:57:4e:83:15:f7:e7:76:51:c6:60:5f:2b:45:59:19:a7:31:9e:98:69:56:4f:01:3c
cloth-config-11.1.136-forge.jar |Cloth Config v10 API |cloth_config |11.1.136
|DONE |Manifest: NOSIGNATURE worldedit-hang-fix-v1.0.5-mc1.18.2-forge.jar
|worldedit-hang-fix |worldedithangfix |1.0.5 |DONE |Manifest: NOSIGNATURE
forge-1.20.1-47.4.20-universal.jar |Forge |forge |47.4.20 |DONE |Manifest:
NOSIGNATURE appleskin-forge-mc1.20.1-2.5.1.jar |AppleSkin |appleskin
|2.5.1+mc1.20.1 |DONE |Manifest: NOSIGNATURE SJAP_Resharpened-1.20.1-1.2.16.jar
|SlashBlade Japanese Addon Pack|slashblade_addon |1.2.16 |DONE |Manifest:
NOSIGNATURE sodiumdynamiclights-forge-1.0.10-1.20.1.jar |Sodium Dynamic Lights
|sodiumdynamiclights |1.0.9 |DONE |Manifest: NOSIGNATURE
embeddium-0.3.31+mc1.20.1.jar |Embeddium |embeddium |0.3.31+mc1.20.1 |DONE
|Manifest: NOSIGNATURE chloride-FORGE-mc1.20.1-v1.7.7.jar |Chloride |chloride
|1.7.7 |DONE |Manifest: NOSIGNATURE Crash Report UUID:
bf688d4e-caf5-4227-8da9-a7ef56948244 FML: 47.4 Forge:
net.minecraftforge:47.4.20⏎
```