### PR TITLE
build(gradle): fix acceleratedrendering dependency and robustify maven_loc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     compileOnly           "org.projectlombok:lombok:1.18.38"
     annotationProcessor   "org.projectlombok:lombok:1.18.38"
 
-    implementation "maven.modrinth:acceleratedrendering:1.0.8-1.21.1-alpha"
+    implementation "curse.maven:accelerated-rendering-1314021:7342942"
 
     implementation "dev.kosmx.player-anim:player-animation-lib-forge:${project.player_anim}"
 
@@ -187,16 +187,22 @@ java {
     withSourcesJar()
 }
 
-publishing {
-    publications {
-        register('mavenJava', MavenPublication) {
-            artifact jar
-        }
-    }
+def hasCustomLoc = project.hasProperty('maven_loc')
+def hasDefaultLoc = project.hasProperty('default_maven_loc')
+def defaultFolder = hasDefaultLoc ? file(project.property('default_maven_loc').toString()) : null
 
-    repositories {
-        maven {
-            url "file://${maven_loc}"
+if (hasCustomLoc || (defaultFolder != null && defaultFolder.exists())) {
+    publishing {
+        publications {
+            register('mavenJava', MavenPublication) {
+                artifact jar
+            }
+        }
+
+        repositories {
+            maven {
+                url = hasCustomLoc ? "file://${project.property('maven_loc')}" : defaultFolder.toURI()
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,12 @@ loader_version_range=[1,)
 jei_version=19.27.0.340
 emi_version=1.1.22+1.21.1
 
-maven_loc = /D:/maven/MMMaven/repository
+# Local Maven repository configuration for publishing.
+# - To use a custom path, uncomment 'maven_loc' and set your path.
+# - If 'maven_loc' is commented out, 'default_maven_loc' will be used as a fallback.
+# - If neither path exists on your system, the local publishing task is safely ignored/skipped.
+#maven_loc =
+default_maven_loc = /D:/maven/MMMaven/repository
 
 mod_id=slashblade
 mod_name=Slash Blade:Resharpened


### PR DESCRIPTION
# Description
This PR addresses two build-related issues to improve repository portability and fix broken dependencies:

1. **Fix Broken Dependency**: Switched `acceleratedrendering` from a non-existent Modrinth coordinates to a valid CurseMaven coordinate.
2. **Robust Local Publishing**: Refactored the `publishing` block to avoid absolute path dependencies. It now uses `default_maven_loc` as a fallback and safely skips the block if neither path exists, preventing build errors on other developers' environments (like macOS).

No logic inside the mod is modified. Testing completed on macOS (M4).