### PR TITLE
修复极佳模式下拔刀剑无法正常渲染。

### DIFF
--- a/src/main/java/mods/flammpfeil/slashblade/client/renderer/util/BladeRenderState.java
+++ b/src/main/java/mods/flammpfeil/slashblade/client/renderer/util/BladeRenderState.java
@@ -134,7 +134,7 @@ public class BladeRenderState extends RenderStateShard {
         return slashBladeBlendCache.computeIfAbsent(texture, t -> {
             RenderType.CompositeState state = RenderType.CompositeState.builder()
                     .setShaderState(RenderStateShard.RENDERTYPE_ITEM_ENTITY_TRANSLUCENT_CULL_SHADER)
-                    .setOutputState(RenderStateShard.ITEM_ENTITY_TARGET)
+                    .setOutputState(RenderStateShard.MAIN_TARGET)
                     .setTextureState(new RenderStateShard.TextureStateShard(t, false, true))
                     .setTransparencyState(RenderStateShard.TRANSLUCENT_TRANSPARENCY)
                     .setLightmapState(LIGHTMAP)
@@ -157,7 +157,7 @@ public class BladeRenderState extends RenderStateShard {
                 .setCullState(NO_CULL)
                 .setDepthTestState(EQUAL_DEPTH_TEST)
                 .setTransparencyState(GLINT_TRANSPARENCY)
-                .setOutputState(ITEM_ENTITY_TARGET)
+                .setOutputState(MAIN_TARGET)
                 .setTexturingState(ENTITY_GLINT_TEXTURING)
                 .setOverlayState(OVERLAY)
                 .createCompositeState(false);
@@ -175,7 +175,7 @@ public class BladeRenderState extends RenderStateShard {
                 .setCullState(NO_CULL)
                 .setDepthTestState(EQUAL_DEPTH_TEST)
                 .setTransparencyState(GLINT_TRANSPARENCY)
-                .setOutputState(ITEM_ENTITY_TARGET)
+                .setOutputState(MAIN_TARGET)
                 .setTexturingState(GLINT_TEXTURING)
                 .setOverlayState(OVERLAY)
                 .createCompositeState(false);
@@ -187,7 +187,7 @@ public class BladeRenderState extends RenderStateShard {
         return slashBladeBlendColorWriteCache.computeIfAbsent(texture, t -> {
             RenderType.CompositeState state = RenderType.CompositeState.builder()
                     .setShaderState(RenderStateShard.RENDERTYPE_ENTITY_TRANSLUCENT_EMISSIVE_SHADER)
-                    .setOutputState(RenderStateShard.ITEM_ENTITY_TARGET)
+                    .setOutputState(RenderStateShard.MAIN_TARGET)
                     .setTextureState(new RenderStateShard.TextureStateShard(t, false, true))
                     .setTransparencyState(LIGHTNING_ADDITIVE_TRANSPARENCY)
                     .setLightmapState(LIGHTMAP)
@@ -215,7 +215,7 @@ public class BladeRenderState extends RenderStateShard {
         return slashBladeBlendLuminousCache.computeIfAbsent(texture, t -> {
             RenderType.CompositeState state = RenderType.CompositeState.builder()
                     .setShaderState(RenderStateShard.RENDERTYPE_ENTITY_TRANSLUCENT_EMISSIVE_SHADER)
-                    .setOutputState(ITEM_ENTITY_TARGET)
+                    .setOutputState(MAIN_TARGET)
                     .setCullState(RenderStateShard.NO_CULL)
                     .setTextureState(new RenderStateShard.TextureStateShard(t, true, true))
                     .setTransparencyState(LIGHTNING_ADDITIVE_TRANSPARENCY)
@@ -234,7 +234,7 @@ public class BladeRenderState extends RenderStateShard {
         return chargeEffectCache.computeIfAbsent(key, k -> {
             RenderType.CompositeState state = RenderType.CompositeState.builder()
                     .setShaderState(RENDERTYPE_ENERGY_SWIRL_SHADER)
-                    .setOutputState(ITEM_ENTITY_TARGET)
+                    .setOutputState(MAIN_TARGET)
                     .setCullState(RenderStateShard.NO_CULL)
                     .setTextureState(new RenderStateShard.TextureStateShard(k.texture, false, true))
                     .setTexturingState(new RenderStateShard.OffsetTexturingStateShard(k.x, k.y))
@@ -253,7 +253,7 @@ public class BladeRenderState extends RenderStateShard {
         return luminousDepthWriteCache.computeIfAbsent(texture, t -> {
             RenderType.CompositeState state = RenderType.CompositeState.builder()
                     .setShaderState(RENDERTYPE_ENTITY_TRANSLUCENT_EMISSIVE_SHADER)
-                    .setOutputState(RenderStateShard.PARTICLES_TARGET)
+                    .setOutputState(RenderStateShard.MAIN_TARGET)
                     .setCullState(RenderStateShard.NO_CULL)
                     .setTextureState(new RenderStateShard.TextureStateShard(t, true, true))
                     .setTransparencyState(LIGHTNING_ADDITIVE_TRANSPARENCY)
@@ -284,7 +284,7 @@ public class BladeRenderState extends RenderStateShard {
         return reverseLuminousCache.computeIfAbsent(texture, t -> {
             RenderType.CompositeState state = RenderType.CompositeState.builder()
                     .setShaderState(RENDERTYPE_ENTITY_TRANSLUCENT_EMISSIVE_SHADER)
-                    .setOutputState(RenderStateShard.ITEM_ENTITY_TARGET)
+                    .setOutputState(RenderStateShard.MAIN_TARGET)
                     .setTextureState(new RenderStateShard.TextureStateShard(t, true, true))
                     .setTransparencyState(LIGHTNING_REVERSE_TRANSPARENCY)
                     .setLightmapState(RenderStateShard.LIGHTMAP)


### PR DESCRIPTION
渲染内容传入item_entity（物品实体帧缓冲）、particles （绑定粒子帧缓冲），本意是为了解决半透明混合的，但只有第三人称的渲染才能正确应用，第一人称和物品渲染无法正常渲染。
而这几个帧缓冲只有在极佳！图像品质才会启用（其它画质还是传入到mainTarget），所以导致了在极佳模式下模型渲染丢失。
此处将所有渲染输出到mainTarget使极佳与其它模式保持一致。