### PR TITLE
修复因为新增NBT在Codec设置为必填，而旧版本的刀没有该数据导致旧刀同步时炸了整个NBT的bug

### DIFF
--- a/src/main/java/mods/flammpfeil/slashblade/capability/slashblade/BladeStateData.java
+++ b/src/main/java/mods/flammpfeil/slashblade/capability/slashblade/BladeStateData.java
@@ -105,7 +105,7 @@ public record BladeStateData(
         Codec.BOOL.fieldOf("sealed").forGetter(CoreFields::sealed),
         ResourceLocation.CODEC.fieldOf("slashArtsKey").forGetter(CoreFields::slashArtsKey),
         Codec.BOOL.fieldOf("defaultBewitched").forGetter(CoreFields::defaultBewitched),
-        Codec.BOOL.fieldOf("destructable").forGetter(CoreFields::destructable)
+        Codec.BOOL.optionalFieldOf("destructable", false).forGetter(CoreFields::destructable)
     ).apply(instance, CoreFields::new));
     
     private static final MapCodec<RenderFields> RENDER_CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(


### PR DESCRIPTION
修复因为新增NBT在Codec设置为必填，而旧版本的刀没有该数据导致旧刀同步时炸了整个NBT的bug