### PR TITLE
修复bug添加可攻击实体白名单

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,11 @@ dependencies {
     compileOnly           "org.projectlombok:lombok:1.18.38"
     annotationProcessor   "org.projectlombok:lombok:1.18.38"
 
+    // 假人
+    runtimeOnly "curse.maven:powerful-dummy-1276893:8232901"
+    runtimeOnly "curse.maven:selene-499980:8749776"
+    runtimeOnly "curse.maven:mmmmmmmmmmmm-225738:8510632"
+
     // 1.0.8 加速渲染
     compileOnly "curse.maven:accelerated-rendering-1314021:7342942"
     // 1.8.12 iris

--- a/src/generated/resources/.cache/5d9383299a3eaab698f9aaee4863de9c3b6262d0
+++ b/src/generated/resources/.cache/5d9383299a3eaab698f9aaee4863de9c3b6262d0
@@ -1,3 +1,4 @@
-// 1.21.1	2026-05-03T02:11:01.4933576	Tags for minecraft:entity_type mod id slashblade
+// 1.21.1	2026-09-02T17:23:20.8910112	Tags for minecraft:entity_type mod id slashblade
 6659f307917d4e6c4e87d8eebb82cd07b8e224f3 data/slashblade/tags/entity_type/blacklist/attackable.json
 8802b5cb055472383f4eb497e52248c046fd9a84 data/slashblade/tags/entity_type/blacklist/render_layer.json
+8c3e275cda6ac98f21eface83b369e2cf9532b93 data/slashblade/tags/entity_type/whitelist/attackable.json

--- a/src/generated/resources/data/slashblade/tags/entity_type/whitelist/attackable.json
+++ b/src/generated/resources/data/slashblade/tags/entity_type/whitelist/attackable.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    {
+      "id": "powerful_dummy:test_dummy",
+      "required": false
+    },
+    {
+      "id": "dummmmmmy:target_dummy",
+      "required": false
+    }
+  ]
+}

--- a/src/main/java/mods/flammpfeil/slashblade/data/tag/SlashBladeEntityTypeTagProvider.java
+++ b/src/main/java/mods/flammpfeil/slashblade/data/tag/SlashBladeEntityTypeTagProvider.java
@@ -22,6 +22,10 @@ public class SlashBladeEntityTypeTagProvider extends EntityTypeTagsProvider {
     
     @Override
     protected void addTags(Provider lookupProvider) {
+        this.tag(EntityTypeTags.ATTACKABLE_WHITELIST)
+                        .addOptional(ResourceLocation.fromNamespaceAndPath("powerful_dummy", "test_dummy"))
+                        .addOptional(ResourceLocation.fromNamespaceAndPath("dummmmmmy", "target_dummy"));
+
         this.tag(EntityTypeTags.ATTACKABLE_BLACKLIST)
             .add(EntityType.VILLAGER)
             .addOptional(ResourceLocation.fromNamespaceAndPath("touhou_little_maid", "maid"));
@@ -31,6 +35,9 @@ public class SlashBladeEntityTypeTagProvider extends EntityTypeTagsProvider {
     }
     
     public static class EntityTypeTags {
+        public static final TagKey<EntityType<?>> ATTACKABLE_WHITELIST = TagKey.create(Registries.ENTITY_TYPE,
+                        SlashBlade.prefix("whitelist/attackable"));
+
         public static final TagKey<EntityType<?>> ATTACKABLE_BLACKLIST = TagKey.create(Registries.ENTITY_TYPE,
             SlashBlade.prefix("blacklist/attackable"));
         public static final TagKey<EntityType<?>> RENDER_LAYER_BLACKLIST = TagKey.create(Registries.ENTITY_TYPE,

--- a/src/main/java/mods/flammpfeil/slashblade/registry/ComboStateRegistry.java
+++ b/src/main/java/mods/flammpfeil/slashblade/registry/ComboStateRegistry.java
@@ -1195,13 +1195,13 @@ public class ComboStateRegistry {
         );
     
     public static final DeferredHolder<ComboState, ComboState> PIERCING = COMBO_STATE.register("piercing", ComboState.Builder
-        .newInstance().startAndEnd(1, 33).priority(50).motionLoc(DefaultResources.testLocation)
+        .newInstance().startAndEnd(1, 28).priority(50).motionLoc(DefaultResources.testLocation)
         .next(entity -> SlashBlade.prefix("piercing"))
         .nextOfTimeout(entity -> SlashBlade.prefix("piercing_2"))
         ::build);
     
     public static final DeferredHolder<ComboState, ComboState> PIERCING_2 = COMBO_STATE.register("piercing_2", ComboState.Builder
-        .newInstance().startAndEnd(33, 55).priority(50).motionLoc(DefaultResources.testLocation)
+        .newInstance().startAndEnd(29, 55).priority(50).motionLoc(DefaultResources.testLocation)
         .next(ComboState.TimeoutNext.buildFromFrame(10, entity -> SlashBlade.prefix("none")))
         .nextOfTimeout(entity -> SlashBlade.prefix("piercing_end"))
         .addTickAction((entity) -> {

--- a/src/main/java/mods/flammpfeil/slashblade/util/TargetSelector.java
+++ b/src/main/java/mods/flammpfeil/slashblade/util/TargetSelector.java
@@ -13,6 +13,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.OwnableEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.targeting.TargetingConditions;
@@ -74,6 +75,17 @@ public class TargetSelector {
             
             if (livingentity.getTags().contains(AttackableTag)) {
                 livingentity.removeTag(AttackableTag);
+                return true;
+            }
+
+            // 防误伤宠物机制
+            if (livingentity instanceof OwnableEntity ownable) {
+                if (ownable.getOwner() instanceof Player) {
+                    return false;
+                }
+            }
+
+            if (livingentity.getType().is(EntityTypeTags.ATTACKABLE_WHITELIST)) {
                 return true;
             }
             


### PR DESCRIPTION
1.修复平突和动画不匹配的bug
2.添加可攻击实体白名单（添加进白名单的实体将可以被攻击）
3.添加防误伤宠物机制（无法直接对宠物造成伤害）